### PR TITLE
Exception thrown if ServiceType is already an interface

### DIFF
--- a/Sources/ServiceModel.Grpc.AspNetCore/Internal/ApiExplorer/ApiDescriptionGenerator.cs
+++ b/Sources/ServiceModel.Grpc.AspNetCore/Internal/ApiExplorer/ApiDescriptionGenerator.cs
@@ -110,7 +110,9 @@ namespace ServiceModel.Grpc.AspNetCore.Internal.ApiExplorer
             GrpcMethodMetadata metadata,
             OperationDescription operation)
         {
-            var serviceInstanceMethod = ReflectionTools.ImplementationOfMethod(
+            var serviceInstanceMethod = metadata.ServiceType.IsInterface
+                ? operation.Message.Operation
+                : ReflectionTools.ImplementationOfMethod(
                 metadata.ServiceType,
                 operation.Message.Operation.DeclaringType!,
                 operation.Message.Operation);


### PR DESCRIPTION
The following exception is thrown when registering the service via an interface and the swagger integration is used.

```
System.ArgumentException: 'this' type cannot be an interface itself.
   at System.RuntimeTypeHandle.VerifyInterfaceIsImplemented(RuntimeTypeHandle interfaceHandle)
   at System.RuntimeType.GetInterfaceMap(Type ifaceType)
   at ServiceModel.Grpc.Internal.ReflectionTools.ImplementationOfMethod(Type instance, Type methodDeclaringType, MethodInfo method)
   at ServiceModel.Grpc.AspNetCore.Internal.ApiExplorer.ApiDescriptionGenerator.CreateApiDescription(RouteEndpoint endpoint, GrpcMethodMetadata metadata, OperationDescription operation)
   at ServiceModel.Grpc.AspNetCore.Internal.ApiExplorer.ApiDescriptionGenerator.TryCreateApiDescription(RouteEndpoint endpoint)
   at ServiceModel.Grpc.AspNetCore.Internal.ApiExplorer.ApiDescriptionProvider.OnProvidersExecuted(ApiDescriptionProviderContext context)
   at Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescriptionGroupCollectionProvider.GetCollection(ActionDescriptorCollection actionDescriptors)
   at Microsoft.AspNetCore.Mvc.ApiExplorer.ApiDescriptionGroupCollectionProvider.get_ApiDescriptionGroups()
   at Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator.GetSwagger(String documentName, String host, String basePath)
   at Swashbuckle.AspNetCore.Swagger.SwaggerMiddleware.Invoke(HttpContext httpContext, ISwaggerProvider swaggerProvider)
   at Microsoft.AspNetCore.Watch.BrowserRefresh.BrowserRefreshMiddleware.InvokeAsync(HttpContext context)
   at Microsoft.AspNetCore.Builder.Extensions.MapWhenMiddleware.Invoke(HttpContext context)
   at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.HttpProtocol.ProcessRequests[TContext](IHttpApplication`1 application)
```

Using the example swagger integration application changing the Calculator registration to use it's interface instead shows this problem.
```
public void ConfigureServices(IServiceCollection services)
{
...
            // enable ServiceModel.Grpc
            services.AddServiceModelGrpc();
            services.AddTransient<ICalculator, Calculator>();
            services.AddServiceModelGrpcSwagger();
...
}

public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
{
...
            app.UseEndpoints(endpoints =>
            {
                endpoints.MapGrpcService<FigureService>();
                endpoints.MapGrpcService<ICalculator>();
            });
...
}
```
