### PR TITLE
bugfix/grpc-core-server-extensions

### DIFF
--- a/Sources/ServiceModel.Grpc.DesignTime.Generator.Test/AspNetCore/TrackedFilteredServiceTest.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.Generator.Test/AspNetCore/TrackedFilteredServiceTest.cs
@@ -40,7 +40,7 @@ public class TrackedFilteredServiceTest : TrackedFilteredServiceTestBase
                 {
                     options.Filters.Add(1, _ => new TrackingServerFilter("global"));
                 });
-                services.AddServiceModelGrpcServiceOptions<TrackedFilteredService>(options =>
+                services.AddTrackedFilteredServiceOptions(options =>
                 {
                     options.Filters.Add(2, _ => new TrackingServerFilter("service-options"));
                 });

--- a/Sources/ServiceModel.Grpc.DesignTime.Shared/Internal/CSharp/CSharpServiceSelfHostAddProviderServiceBuilder.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.Shared/Internal/CSharp/CSharpServiceSelfHostAddProviderServiceBuilder.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 Max Ieremenko
+// Copyright 2021-2022 Max Ieremenko
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -57,7 +57,9 @@ internal sealed class CSharpServiceSelfHostAddProviderServiceBuilder : CodeGener
                 .AppendTypeName("Grpc.Core", "ServiceDefinitionCollectionExtensions")
                 .Append(".AddServiceModel<")
                 .Append(_contract.ContractInterfaceName)
-                .AppendLine(">(services, serviceProvider, configure);");
+                .Append(">(services, serviceProvider, new ")
+                .Append(_contract.EndpointBinderClassName)
+                .AppendLine("(), configure);");
         }
 
         Output.AppendLine("}");

--- a/Sources/ServiceModel.Grpc.DesignTime.Shared/Internal/CSharp/CSharpServiceSelfHostAddSingletonServiceBuilder.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.Shared/Internal/CSharp/CSharpServiceSelfHostAddSingletonServiceBuilder.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2020 Max Ieremenko
+// Copyright 2020-2022 Max Ieremenko
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,7 +56,11 @@ internal sealed class CSharpServiceSelfHostAddSingletonServiceBuilder : CodeGene
             Output
                 .Append("return ")
                 .AppendTypeName("Grpc.Core", "ServiceDefinitionCollectionExtensions")
-                .AppendLine(".AddServiceModelSingleton(services, service, configure);");
+                .Append(".AddServiceModelSingleton<")
+                .Append(_contract.ContractInterfaceName)
+                .Append(">(services, service, new ")
+                .Append(_contract.EndpointBinderClassName)
+                .AppendLine("(), configure);");
         }
 
         Output.AppendLine("}");

--- a/Sources/ServiceModel.Grpc.DesignTime.Shared/Internal/CSharp/CSharpServiceSelfHostAddTransientServiceBuilder.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.Shared/Internal/CSharp/CSharpServiceSelfHostAddTransientServiceBuilder.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2020 Max Ieremenko
+// Copyright 2020-2022 Max Ieremenko
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -56,7 +56,11 @@ internal sealed class CSharpServiceSelfHostAddTransientServiceBuilder : CodeGene
             Output
                 .Append("return ")
                 .AppendTypeName("Grpc.Core", "ServiceDefinitionCollectionExtensions")
-                .AppendLine(".AddServiceModelTransient(services, serviceFactory, configure);");
+                .Append(".AddServiceModelTransient<")
+                .Append(_contract.ContractInterfaceName)
+                .Append(">(services, serviceFactory, new ")
+                .Append(_contract.EndpointBinderClassName)
+                .AppendLine("(), configure);");
         }
 
         Output.AppendLine("}");

--- a/Sources/ServiceModel.Grpc.DesignTime.Test/Generator/Internal/CSharp/CSharpServiceSelfHostAddProviderServiceBuilderTest.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.Test/Generator/Internal/CSharp/CSharpServiceSelfHostAddProviderServiceBuilderTest.cs
@@ -1,0 +1,48 @@
+﻿// <copyright>
+// Copyright 2022 Max Ieremenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using NUnit.Framework;
+using ServiceModel.Grpc.TestApi;
+using ServiceModel.Grpc.TestApi.Domain;
+using Shouldly;
+
+namespace ServiceModel.Grpc.DesignTime.Generator.Internal.CSharp;
+
+[TestFixture]
+public class CSharpServiceSelfHostAddProviderServiceBuilderTest
+{
+    private ContractDescription _contract = null!;
+
+    [OneTimeSetUp]
+    public void BeforeAll()
+    {
+        _contract = ContractDescriptionFactory.Create(typeof(IContract));
+    }
+
+    [Test]
+    public void GenerateMemberDeclaration()
+    {
+        var sut = new CSharpServiceSelfHostAddProviderServiceBuilder(_contract, true);
+
+        var code = new CodeStringBuilder();
+        sut.GenerateMemberDeclaration(code);
+        var actual = code.AsStringBuilder().ToString();
+        TestOutput.WriteLine(actual);
+
+        actual.ShouldContain("IServiceProvider serviceProvider");
+        actual.ShouldContain("new " + _contract.EndpointBinderClassName + "()");
+    }
+}

--- a/Sources/ServiceModel.Grpc.DesignTime.Test/Generator/Internal/CSharp/CSharpServiceSelfHostAddSingletonServiceBuilderTest.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.Test/Generator/Internal/CSharp/CSharpServiceSelfHostAddSingletonServiceBuilderTest.cs
@@ -1,0 +1,48 @@
+﻿// <copyright>
+// Copyright 2022 Max Ieremenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using NUnit.Framework;
+using ServiceModel.Grpc.TestApi;
+using ServiceModel.Grpc.TestApi.Domain;
+using Shouldly;
+
+namespace ServiceModel.Grpc.DesignTime.Generator.Internal.CSharp;
+
+[TestFixture]
+public class CSharpServiceSelfHostAddSingletonServiceBuilderTest
+{
+    private ContractDescription _contract = null!;
+
+    [OneTimeSetUp]
+    public void BeforeAll()
+    {
+        _contract = ContractDescriptionFactory.Create(typeof(IContract));
+    }
+
+    [Test]
+    public void GenerateMemberDeclaration()
+    {
+        var sut = new CSharpServiceSelfHostAddSingletonServiceBuilder(_contract, true);
+
+        var code = new CodeStringBuilder();
+        sut.GenerateMemberDeclaration(code);
+        var actual = code.AsStringBuilder().ToString();
+        TestOutput.WriteLine(actual);
+
+        actual.ShouldContain("IContract service,");
+        actual.ShouldContain("new " + _contract.EndpointBinderClassName + "()");
+    }
+}

--- a/Sources/ServiceModel.Grpc.DesignTime.Test/Generator/Internal/CSharp/CSharpServiceSelfHostAddTransientServiceBuilderTest.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.Test/Generator/Internal/CSharp/CSharpServiceSelfHostAddTransientServiceBuilderTest.cs
@@ -1,0 +1,48 @@
+﻿// <copyright>
+// Copyright 2022 Max Ieremenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using NUnit.Framework;
+using ServiceModel.Grpc.TestApi;
+using ServiceModel.Grpc.TestApi.Domain;
+using Shouldly;
+
+namespace ServiceModel.Grpc.DesignTime.Generator.Internal.CSharp;
+
+[TestFixture]
+public class CSharpServiceSelfHostAddTransientServiceBuilderTest
+{
+    private ContractDescription _contract = null!;
+
+    [OneTimeSetUp]
+    public void BeforeAll()
+    {
+        _contract = ContractDescriptionFactory.Create(typeof(IContract));
+    }
+
+    [Test]
+    public void GenerateMemberDeclaration()
+    {
+        var sut = new CSharpServiceSelfHostAddTransientServiceBuilder(_contract, true);
+
+        var code = new CodeStringBuilder();
+        sut.GenerateMemberDeclaration(code);
+        var actual = code.AsStringBuilder().ToString();
+        TestOutput.WriteLine(actual);
+
+        actual.ShouldContain("IContract> serviceFactory,");
+        actual.ShouldContain("new " + _contract.EndpointBinderClassName + "()");
+    }
+}

--- a/Sources/ServiceModel.Grpc.DesignTime.Test/Generator/Internal/CSharp/ContractDescriptionFactory.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.Test/Generator/Internal/CSharp/ContractDescriptionFactory.cs
@@ -1,0 +1,42 @@
+﻿// <copyright>
+// Copyright 2022 Max Ieremenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System;
+using System.ServiceModel;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace ServiceModel.Grpc.DesignTime.Generator.Internal.CSharp;
+
+internal static class ContractDescriptionFactory
+{
+    public static ContractDescription Create(Type serviceType)
+    {
+        var compilation = CSharpCompilation
+            .Create(
+                nameof(CSharpServiceSelfHostAddProviderServiceBuilderTest),
+                references: new[]
+                {
+                    MetadataReference.CreateFromFile(typeof(string).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(ContractDescriptionFactory).Assembly.Location),
+                    MetadataReference.CreateFromFile(typeof(ServiceContractAttribute).Assembly.Location),
+                    MetadataReference.CreateFromFile(serviceType.Assembly.Location)
+                });
+
+        var symbol = compilation.GetTypeByMetadataName(serviceType);
+        return new ContractDescription(symbol);
+    }
+}

--- a/Sources/ServiceModel.Grpc.SelfHost/ServiceDefinitionCollectionExtensions.cs
+++ b/Sources/ServiceModel.Grpc.SelfHost/ServiceDefinitionCollectionExtensions.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2020 Max Ieremenko
+// Copyright 2020-2022 Max Ieremenko
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -87,6 +87,7 @@ public static class ServiceDefinitionCollectionExtensions
         Action<ServiceModelGrpcServiceOptions>? configure = default)
     {
         services.AssertNotNull(nameof(services));
+        service.AssertNotNull(nameof(service));
 
         BindService(services, () => service, null, configure);
         return services;
@@ -109,7 +110,8 @@ public static class ServiceDefinitionCollectionExtensions
         Action<ServiceModelGrpcServiceOptions>? configure = default)
     {
         services.AssertNotNull(nameof(services));
-        services.AssertNotNull(nameof(endpointBinder));
+        service.AssertNotNull(nameof(service));
+        endpointBinder.AssertNotNull(nameof(endpointBinder));
 
         BindService(services, () => service, endpointBinder, configure);
         return services;
@@ -130,6 +132,36 @@ public static class ServiceDefinitionCollectionExtensions
     {
         services.AssertNotNull(nameof(services));
         serviceProvider.AssertNotNull(nameof(serviceProvider));
+
+        Func<TService> serviceFactory = serviceProvider.GetServiceRequired<TService>;
+        var options = new ServiceModelGrpcServiceOptions
+        {
+            ServiceProvider = serviceProvider
+        };
+
+        BindService(services, serviceFactory, null, configure, options);
+        return services;
+    }
+
+    /// <summary>
+    /// Registers a ServiceModel.Grpc service in the <see cref="Server.ServiceDefinitionCollection"/>.
+    /// This method used by generated source code.
+    /// </summary>
+    /// <typeparam name="TService">The implementation type of ServiceModel.Grpc service.</typeparam>
+    /// <param name="services">The <see cref="Server.ServiceDefinitionCollection"/>.</param>
+    /// <param name="serviceProvider">See <see cref="IServiceProvider"/>.</param>
+    /// <param name="endpointBinder">The generated service endpoint binder.</param>
+    /// <param name="configure">The optional configuration action to provide a configuration the service.</param>
+    /// <returns><see cref="Server.ServiceDefinitionCollection"/>.</returns>
+    public static Server.ServiceDefinitionCollection AddServiceModel<TService>(
+        this Server.ServiceDefinitionCollection services,
+        IServiceProvider serviceProvider,
+        IServiceEndpointBinder<TService> endpointBinder,
+        Action<ServiceModelGrpcServiceOptions>? configure = default)
+    {
+        services.AssertNotNull(nameof(services));
+        serviceProvider.AssertNotNull(nameof(serviceProvider));
+        endpointBinder.AssertNotNull(nameof(endpointBinder));
 
         Func<TService> serviceFactory = serviceProvider.GetServiceRequired<TService>;
         var options = new ServiceModelGrpcServiceOptions


### PR DESCRIPTION
Generated C# extension methods for Grpc.Core.Server ignored endpoint binder and as a result, the "reflection emit" endpoint binder was used. Generated code example:

``` c#
public static ServiceDefinitionCollection AddMyService(
    this ServiceDefinitionCollection services,
    MyService service,
    Action<ServiceModelGrpcServiceOptions> configure = default)
{
    // incorrect
    return .AddServiceModelSingleton<MyService>(services, service, configure);
    // must be
    return .AddServiceModelSingleton<MyService>(services, service, new MyServiceEndpointBinder(), configure);
}

public static ServiceDefinitionCollection AddMyService(
    this ServiceDefinitionCollection services,
    Func<MyService> serviceFactory,
    Action<ServiceModelGrpcServiceOptions> configure = default)
{
    // incorrect
    return .AddServiceModelTransient<MyService>(services, serviceFactory, configure);
    // must be
    return .AddServiceModelTransient<MyService>(services, serviceFactory, new MyServiceEndpointBinder(), configure);
}

public static ServiceDefinitionCollection AddMyService(
    this ServiceDefinitionCollection services,
    IServiceProvider serviceProvider,
    Action<ServiceModelGrpcServiceOptions> configure = default)
{
    // incorrect
    return .AddServiceModel<MyService>(services, AddServiceModel, configure);
    // must be
    return .AddServiceModel<MyService>(services, AddServiceModel, new MyServiceEndpointBinder(), configure);
}
```