### PR TITLE
improve error handler logging

### DIFF
--- a/Examples/ErrorHandling/Client/Program.cs
+++ b/Examples/ErrorHandling/Client/Program.cs
@@ -13,6 +13,9 @@ public static class Program
 {
     private static readonly IClientFactory DefaultClientFactory = new ClientFactory(new ServiceModelGrpcClientOptions
     {
+        // enable ServiceModel.Grpc logging
+        Logger = new SimpleConsoleLogger(),
+
         // combine application and unexpected handlers into one handler
         ErrorHandler = new ClientErrorHandlerCollection(new ApplicationExceptionClientHandler(), new UnexpectedExceptionClientHandler())
     });

--- a/Examples/ErrorHandling/Client/SimpleConsoleLogger.cs
+++ b/Examples/ErrorHandling/Client/SimpleConsoleLogger.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using ServiceModel.Grpc;
+
+namespace Client;
+
+internal sealed class SimpleConsoleLogger : ILogger
+{
+    public void LogError(string message, params object[] args) => Log("error", message, args);
+
+    public void LogWarning(string message, params object[] args) => Log("warn", message, args);
+
+    public void LogDebug(string message, params object[] args) => Log("info", message, args);
+
+    private static void Log(string category, string message, params object[] args)
+    {
+        Console.WriteLine("{0} {1}", category, string.Format(message, args));
+    }
+}

--- a/Examples/ErrorHandling/ClientDesignTime/Program.cs
+++ b/Examples/ErrorHandling/ClientDesignTime/Program.cs
@@ -13,6 +13,9 @@ public static class Program
 {
     private static readonly IClientFactory DefaultClientFactory = new ClientFactory(new ServiceModelGrpcClientOptions
     {
+        // enable ServiceModel.Grpc logging
+        Logger = new SimpleConsoleLogger(),
+
         // combine application and unexpected handlers into one handler
         ErrorHandler = new ClientErrorHandlerCollection(new ApplicationExceptionClientHandler(), new UnexpectedExceptionClientHandler())
     });

--- a/Examples/ErrorHandling/ClientDesignTime/SimpleConsoleLogger.cs
+++ b/Examples/ErrorHandling/ClientDesignTime/SimpleConsoleLogger.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using ServiceModel.Grpc;
+
+namespace ClientDesignTime;
+
+internal sealed class SimpleConsoleLogger : ILogger
+{
+    public void LogError(string message, params object[] args) => Log("error", message, args);
+
+    public void LogWarning(string message, params object[] args) => Log("warn", message, args);
+
+    public void LogDebug(string message, params object[] args) => Log("info", message, args);
+
+    private static void Log(string category, string message, params object[] args)
+    {
+        Console.WriteLine("{0} {1}", category, string.Format(message, args));
+    }
+}

--- a/Examples/ErrorHandling/ServerNativeHost/ServerHost.cs
+++ b/Examples/ErrorHandling/ServerNativeHost/ServerHost.cs
@@ -5,6 +5,7 @@ using ServiceModel.Grpc.Interceptors;
 using System.Threading;
 using System.Threading.Tasks;
 using Contract;
+using Grpc.Core.Logging;
 
 namespace ServerNativeHost;
 
@@ -26,6 +27,9 @@ internal sealed class ServerHost : IHostedService
             new DebugService(),
             options =>
             {
+                // enable ServiceModel.Grpc logging
+                options.Logger = new ConsoleLogger();
+
                 // combine application and unexpected handlers into one handler
                 options.ErrorHandler = new ServerErrorHandlerCollection(
                     new ApplicationExceptionServerHandler(),

--- a/Sources/ServiceModel.Grpc.AspNetCore/Internal/Binding/PostConfigureGrpcServiceOptions.cs
+++ b/Sources/ServiceModel.Grpc.AspNetCore/Internal/Binding/PostConfigureGrpcServiceOptions.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2020-2022 Max Ieremenko
+// Copyright 2020-2023 Max Ieremenko
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ using System;
 using Grpc.AspNetCore.Server;
 using Grpc.Core.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using ServiceModel.Grpc.Configuration;
 using ServiceModel.Grpc.Interceptors;
@@ -28,10 +29,12 @@ namespace ServiceModel.Grpc.AspNetCore.Internal.Binding;
 internal sealed class PostConfigureGrpcServiceOptions : IPostConfigureOptions<GrpcServiceOptions>
 {
     private readonly IOptions<ServiceModelGrpcServiceOptions> _serviceModelOptions;
+    private readonly ILoggerFactory _loggerFactory;
 
-    public PostConfigureGrpcServiceOptions(IOptions<ServiceModelGrpcServiceOptions> serviceModelOptions)
+    public PostConfigureGrpcServiceOptions(IOptions<ServiceModelGrpcServiceOptions> serviceModelOptions, ILoggerFactory loggerFactory)
     {
         _serviceModelOptions = GrpcPreconditions.CheckNotNull(serviceModelOptions, nameof(serviceModelOptions));
+        _loggerFactory = GrpcPreconditions.CheckNotNull(loggerFactory, nameof(loggerFactory));
     }
 
     public void PostConfigure(string? name, GrpcServiceOptions options)
@@ -39,21 +42,30 @@ internal sealed class PostConfigureGrpcServiceOptions : IPostConfigureOptions<Gr
         AddErrorHandler(
             options.Interceptors,
             _serviceModelOptions.Value.DefaultErrorHandlerFactory,
-            _serviceModelOptions.Value.DefaultMarshallerFactory);
+            _serviceModelOptions.Value.DefaultMarshallerFactory,
+            _loggerFactory);
     }
 
     internal static void AddErrorHandler(
         InterceptorCollection interceptors,
         Func<IServiceProvider, IServerErrorHandler>? errorHandlerFactory,
-        IMarshallerFactory? marshallerFactory)
+        IMarshallerFactory? marshallerFactory,
+        ILoggerFactory loggerFactory)
     {
         if (errorHandlerFactory != null)
         {
             var factory = new ErrorHandlerServerCallInterceptorFactory(
                 marshallerFactory.ThisOrDefault(),
-                errorHandlerFactory);
+                errorHandlerFactory,
+                CreateLogger(loggerFactory));
 
             interceptors.Add<ServerNativeInterceptor>(factory);
         }
+    }
+
+    private static ILogger CreateLogger(ILoggerFactory loggerFactory)
+    {
+        var logger = loggerFactory.CreateLogger(ErrorHandlerServerCallInterceptorFactory.LoggerName);
+        return new LogAdapter(logger);
     }
 }

--- a/Sources/ServiceModel.Grpc.AspNetCore/Internal/Binding/PostConfigureGrpcServiceOptions{TService}.cs
+++ b/Sources/ServiceModel.Grpc.AspNetCore/Internal/Binding/PostConfigureGrpcServiceOptions{TService}.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2020-2022 Max Ieremenko
+// Copyright 2020-2023 Max Ieremenko
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 using Grpc.AspNetCore.Server;
 using Grpc.Core.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace ServiceModel.Grpc.AspNetCore.Internal.Binding;
@@ -26,13 +27,16 @@ internal sealed class PostConfigureGrpcServiceOptions<TService> : IPostConfigure
 {
     private readonly IOptions<ServiceModelGrpcServiceOptions> _rootConfiguration;
     private readonly IOptions<ServiceModelGrpcServiceOptions<TService>> _serviceConfiguration;
+    private readonly ILoggerFactory _loggerFactory;
 
     public PostConfigureGrpcServiceOptions(
         IOptions<ServiceModelGrpcServiceOptions> rootConfiguration,
-        IOptions<ServiceModelGrpcServiceOptions<TService>> serviceConfiguration)
+        IOptions<ServiceModelGrpcServiceOptions<TService>> serviceConfiguration,
+        ILoggerFactory loggerFactory)
     {
         _rootConfiguration = GrpcPreconditions.CheckNotNull(rootConfiguration, nameof(rootConfiguration));
         _serviceConfiguration = GrpcPreconditions.CheckNotNull(serviceConfiguration, nameof(serviceConfiguration));
+        _loggerFactory = GrpcPreconditions.CheckNotNull(loggerFactory, nameof(loggerFactory));
     }
 
     public void PostConfigure(string? name, GrpcServiceOptions<TService> options)
@@ -42,6 +46,7 @@ internal sealed class PostConfigureGrpcServiceOptions<TService> : IPostConfigure
         PostConfigureGrpcServiceOptions.AddErrorHandler(
             options.Interceptors,
             _serviceConfiguration.Value.ErrorHandlerFactory,
-            marshallerFactory);
+            marshallerFactory,
+            _loggerFactory);
     }
 }

--- a/Sources/ServiceModel.Grpc.SelfHost/Internal/LogAdapter.cs
+++ b/Sources/ServiceModel.Grpc.SelfHost/Internal/LogAdapter.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2020 Max Ieremenko
+// Copyright 2020-2023 Max Ieremenko
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,16 +18,21 @@ namespace ServiceModel.Grpc.SelfHost.Internal;
 
 internal sealed class LogAdapter : ILogger
 {
-    private readonly global::Grpc.Core.Logging.ILogger? _logger;
+    private readonly global::Grpc.Core.Logging.ILogger _logger;
 
-    public LogAdapter(global::Grpc.Core.Logging.ILogger? logger)
+    public LogAdapter(global::Grpc.Core.Logging.ILogger logger)
     {
         _logger = logger;
     }
 
-    public void LogError(string message, params object[] args) => _logger?.Error(message, args);
+    public static ILogger? Wrap(global::Grpc.Core.Logging.ILogger? logger)
+    {
+        return logger == null ? null : new LogAdapter(logger);
+    }
 
-    public void LogWarning(string message, params object[] args) => _logger?.Warning(message, args);
+    public void LogError(string message, params object[] args) => _logger.Error(message, args);
 
-    public void LogDebug(string message, params object[] args) => _logger?.Debug(message, args);
+    public void LogWarning(string message, params object[] args) => _logger.Warning(message, args);
+
+    public void LogDebug(string message, params object[] args) => _logger.Debug(message, args);
 }

--- a/Sources/ServiceModel.Grpc.SelfHost/Internal/WithLoggerFactory.cs
+++ b/Sources/ServiceModel.Grpc.SelfHost/Internal/WithLoggerFactory.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2021 Max Ieremenko
+// Copyright 2021-2023 Max Ieremenko
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,22 +15,21 @@
 // </copyright>
 
 using System;
-using IGrpcLogger = global::Grpc.Core.Logging.ILogger;
 
 namespace ServiceModel.Grpc.SelfHost.Internal;
 
 internal sealed class WithLoggerFactory<T>
 {
     private readonly Func<T> _factory;
-    private readonly IGrpcLogger _logger;
+    private readonly ILogger _logger;
 
-    private WithLoggerFactory(Func<T> factory, IGrpcLogger logger)
+    private WithLoggerFactory(Func<T> factory, ILogger logger)
     {
         _factory = factory;
         _logger = logger;
     }
 
-    public static Func<T> Wrap(Func<T> factory, IGrpcLogger? logger)
+    public static Func<T> Wrap(Func<T> factory, ILogger? logger)
     {
         if (logger == null)
         {
@@ -54,7 +53,7 @@ internal sealed class WithLoggerFactory<T>
         }
         catch (Exception ex)
         {
-            _logger.Error("{0} factory failed: {1}", typeof(T).FullName, ex);
+            _logger.LogError("{0} factory failed: {1}", typeof(T).FullName, ex);
             throw;
         }
 

--- a/Sources/ServiceModel.Grpc/Interceptors/Internal/ErrorHandlerServerCallInterceptorFactory.cs
+++ b/Sources/ServiceModel.Grpc/Interceptors/Internal/ErrorHandlerServerCallInterceptorFactory.cs
@@ -1,5 +1,5 @@
 ﻿// <copyright>
-// Copyright 2020 Max Ieremenko
+// Copyright 2020-2023 Max Ieremenko
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,15 +22,20 @@ namespace ServiceModel.Grpc.Interceptors.Internal;
 
 internal sealed class ErrorHandlerServerCallInterceptorFactory : IServerCallInterceptorFactory
 {
+    internal const string LoggerName = "ServiceModel.Grpc.Interceptors.ServerCallErrorInterceptor";
+
     private readonly IMarshallerFactory _marshallerFactory;
     private readonly Func<IServiceProvider, IServerErrorHandler> _errorHandlerFactory;
+    private readonly ILogger? _logger;
 
     public ErrorHandlerServerCallInterceptorFactory(
         IMarshallerFactory marshallerFactory,
-        Func<IServiceProvider, IServerErrorHandler> errorHandlerFactory)
+        Func<IServiceProvider, IServerErrorHandler> errorHandlerFactory,
+        ILogger? logger)
     {
         _marshallerFactory = GrpcPreconditions.CheckNotNull(marshallerFactory, nameof(marshallerFactory));
         _errorHandlerFactory = GrpcPreconditions.CheckNotNull(errorHandlerFactory, nameof(errorHandlerFactory));
+        _logger = logger;
     }
 
     public IServerCallInterceptor CreateInterceptor(IServiceProvider serviceProvider)
@@ -38,6 +43,6 @@ internal sealed class ErrorHandlerServerCallInterceptorFactory : IServerCallInte
         GrpcPreconditions.CheckNotNull(serviceProvider, nameof(serviceProvider));
 
         var errorHandler = _errorHandlerFactory(serviceProvider);
-        return new ServerCallErrorInterceptor(errorHandler, _marshallerFactory);
+        return new ServerCallErrorInterceptor(errorHandler, _marshallerFactory, _logger);
     }
 }


### PR DESCRIPTION
Log exception on
- the user`s ProvideFault in the server error handler interceptor
- fault detail serialization in the server error handler interceptor, related to #148
- fault detail deserialization in client error handler interceptor

Enable logging in the ErrorHandling example