### PR TITLE
ExceptionHandlingTest: relax expectation to TaskCanceledException

### DIFF
--- a/Sources/ServiceModel.Grpc.TestApi/ExceptionHandlingTestBase.cs
+++ b/Sources/ServiceModel.Grpc.TestApi/ExceptionHandlingTestBase.cs
@@ -19,6 +19,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Grpc.Core;
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 using ServiceModel.Grpc.TestApi.Domain;
 using Shouldly;
 
@@ -151,7 +152,7 @@ public abstract class ExceptionHandlingTestBase
         ex.InnerException.ShouldBeOfType<RpcException>().StatusCode.ShouldBe(StatusCode.Internal);
 
         clientStreamWriter.ShouldNotBeNull();
-        Assert.ThrowsAsync<OperationCanceledException>(() => clientStreamWriter);
+        Assert.ThrowsAsync(new InstanceOfTypeConstraint(typeof(OperationCanceledException)), () => clientStreamWriter);
     }
 
     [Test]
@@ -178,7 +179,7 @@ public abstract class ExceptionHandlingTestBase
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
         clientStreamWriter.ShouldNotBeNull();
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-        Assert.ThrowsAsync<OperationCanceledException>(() => clientStreamWriter);
+        Assert.ThrowsAsync(new InstanceOfTypeConstraint(typeof(OperationCanceledException)), () => clientStreamWriter);
     }
 
     [Test]
@@ -272,7 +273,7 @@ public abstract class ExceptionHandlingTestBase
         ex.InnerException.ShouldBeOfType<RpcException>().StatusCode.ShouldBe(StatusCode.Internal);
 
         clientStreamWriter.ShouldNotBeNull();
-        Assert.ThrowsAsync<OperationCanceledException>(() => clientStreamWriter);
+        Assert.ThrowsAsync(new InstanceOfTypeConstraint(typeof(OperationCanceledException)), () => clientStreamWriter);
     }
 
     [Test]
@@ -299,7 +300,7 @@ public abstract class ExceptionHandlingTestBase
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
         clientStreamWriter.ShouldNotBeNull();
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-        Assert.ThrowsAsync<OperationCanceledException>(() => clientStreamWriter);
+        Assert.ThrowsAsync(new InstanceOfTypeConstraint(typeof(OperationCanceledException)), () => clientStreamWriter);
     }
 
     [Test]
@@ -347,7 +348,7 @@ public abstract class ExceptionHandlingTestBase
         ex.InnerException.ShouldBeOfType<RpcException>().StatusCode.ShouldBe(StatusCode.Internal);
 
         clientStreamWriter.ShouldNotBeNull();
-        Assert.ThrowsAsync<OperationCanceledException>(() => clientStreamWriter);
+        Assert.ThrowsAsync(new InstanceOfTypeConstraint(typeof(OperationCanceledException)), () => clientStreamWriter);
     }
 
     [Test]
@@ -373,7 +374,7 @@ public abstract class ExceptionHandlingTestBase
 #pragma warning disable CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
         clientStreamWriter.ShouldNotBeNull();
 #pragma warning restore CS4014 // Because this call is not awaited, execution of the current method continues before the call is completed
-        Assert.ThrowsAsync<OperationCanceledException>(() => clientStreamWriter);
+        Assert.ThrowsAsync(new InstanceOfTypeConstraint(typeof(OperationCanceledException)), () => clientStreamWriter);
     }
 
     [Test]


### PR DESCRIPTION
Related to unstable streaming tests.

```
Failed ThrowApplicationExceptionClientStreamingOnRead [20 ms]
  Error Message:
     Expected: <System.OperationCanceledException>
  But was:  <System.Threading.Tasks.TaskCanceledException: A task was canceled.
   at System.Threading.Channels.ChannelReader`1.ReadAllAsync(CancellationToken cancellationToken)+MoveNext()
   at System.Threading.Channels.ChannelReader`1.ReadAllAsync(CancellationToken cancellationToken)+System.Threading.Tasks.Sources.IValueTaskSource<System.Boolean>.GetResult()
   at ServiceModel.Grpc.Client.Internal.ClientStreamWriter`1.Start(CancellationToken token) in /_/Sources/ServiceModel.Grpc/Client/Internal/ClientStreamWriter.cs:line 71
   at ServiceModel.Grpc.Client.Internal.ClientStreamWriter`1.Start(CancellationToken token) in /_/Sources/ServiceModel.Grpc/Client/Internal/ClientStreamWriter.cs:line 71
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.GetResult()
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Assert.ThrowsAsync(IResolveConstraint expression, AsyncTestDelegate code, String message, Object[] args)>

  Stack Trace:
     at ServiceModel.Grpc.TestApi.ExceptionHandlingTestBase.ThrowApplicationExceptionClientStreamingOnRead() in /_/Sources/ServiceModel.Grpc.TestApi/ExceptionHandlingTestBase.cs:line 181
   at NUnit.Framework.Internal.TaskAwaitAdapter.GenericAdapter`1.GetResult()
   at NUnit.Framework.Internal.AsyncToSyncAdapter.Await(Func`1 invoke)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.RunTestMethod(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.TestMethodCommand.Execute(TestExecutionContext context)
   at NUnit.Framework.Internal.Commands.BeforeAndAfterTestCommand.<>c__DisplayClass1_0.<Execute>b__0()
   at NUnit.Framework.Internal.Commands.DelegatingTestCommand.RunTestMethodInThreadAbortSafeZone(TestExecutionContext context, Action action)

1)    at ServiceModel.Grpc.TestApi.ExceptionHandlingTestBase.ThrowApplicationExceptionClientStreamingOnRead() in /_/Sources/ServiceModel.Grpc.TestApi/ExceptionHandlingTestBase.cs:line 181
   at System.Runtime.CompilerServices.AsyncMethodBuilderCore.Start[TStateMachine](TStateMachine& stateMachine)
   at ServiceModel.Grpc.TestApi.ExceptionHandlingTestBase.ThrowApplicationExceptionClientStreamingOnRead()
   at InvokeStub_ExceptionHandlingTestBase.ThrowApplicationExceptionClientStreamingOnRead(Object, Object, IntPtr*)
```