### PR TITLE
#188: SelfHost, fix attaching custom ServiceDefinition configuration

### DIFF
--- a/Sources/ServiceModel.Grpc.SelfHost.Test/ServerInterceptorTest.Domain.cs
+++ b/Sources/ServiceModel.Grpc.SelfHost.Test/ServerInterceptorTest.Domain.cs
@@ -1,0 +1,48 @@
+﻿// <copyright>
+// Copyright 2024 Max Ieremenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using ServiceModel.Grpc.Channel;
+using ServiceModel.Grpc.TestApi.Domain;
+
+namespace ServiceModel.Grpc.SelfHost;
+
+public partial class ServerInterceptorTest
+{
+    private sealed class HackInterceptor : Interceptor
+    {
+        public override Task<TResponse> UnaryServerHandler<TRequest, TResponse>(
+            TRequest request,
+            ServerCallContext context,
+            UnaryServerMethod<TRequest, TResponse> continuation)
+        {
+            if (context.Method == $"/{nameof(IMultipurposeService)}/{nameof(IMultipurposeService.BlockingCallAsync)}")
+            {
+                HackBlockingCallRequest(request);
+            }
+
+            return continuation(request, context);
+        }
+
+        private static void HackBlockingCallRequest(object request)
+        {
+            var message = (Message<int, string>)request;
+            message.Value2 += "_h_";
+        }
+    }
+}

--- a/Sources/ServiceModel.Grpc.SelfHost.Test/ServerInterceptorTest.cs
+++ b/Sources/ServiceModel.Grpc.SelfHost.Test/ServerInterceptorTest.cs
@@ -1,0 +1,63 @@
+﻿// <copyright>
+// Copyright 2024 Max Ieremenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Threading.Tasks;
+using Grpc.Core;
+using Grpc.Core.Interceptors;
+using NUnit.Framework;
+using ServiceModel.Grpc.Client;
+using ServiceModel.Grpc.TestApi;
+using ServiceModel.Grpc.TestApi.Domain;
+using Shouldly;
+
+namespace ServiceModel.Grpc.SelfHost;
+
+[TestFixture]
+public partial class ServerInterceptorTest
+{
+    private ServerHost _host = null!;
+    private IMultipurposeService _domainService = null!;
+
+    [OneTimeSetUp]
+    public void BeforeAll()
+    {
+        _host = new ServerHost(GrpcChannelType.GrpcCore);
+
+        _host.Services.AddServiceModelSingleton<IMultipurposeService>(
+            new MultipurposeService(),
+            options =>
+            {
+                options.ConfigureServiceDefinition = definition => definition.Intercept(new HackInterceptor());
+            });
+        _host.Start();
+
+        _domainService = new ClientFactory().CreateClient<IMultipurposeService>(_host.Channel);
+    }
+
+    [OneTimeTearDown]
+    public async Task AfterAll()
+    {
+        await _host.DisposeAsync().ConfigureAwait(false);
+    }
+
+    [Test]
+    public async Task BlockingCallAsync()
+    {
+        var result = await _domainService.BlockingCallAsync(default, 1, "dummy").ConfigureAwait(false);
+
+        result.ShouldBe("dummy_h_1");
+    }
+}

--- a/Sources/ServiceModel.Grpc.SelfHost/Internal/ServiceDefinitionFactory.cs
+++ b/Sources/ServiceModel.Grpc.SelfHost/Internal/ServiceDefinitionFactory.cs
@@ -58,7 +58,10 @@ internal static class ServiceDefinitionFactory
 
         var definition = definitionBuilder.Build();
 
-        options?.ConfigureServiceDefinition?.Invoke(definition);
+        if (options?.ConfigureServiceDefinition != null)
+        {
+            definition = options.ConfigureServiceDefinition(definition);
+        }
 
         if (options?.ErrorHandler != null)
         {


### PR DESCRIPTION
During server-side binding, the user-defined `ServiceModelGrpcServiceOptions.ConfigureServiceDefinition` result should be taken into the definitions chain.