### PR TITLE
build actions v4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       shell: pwsh
@@ -37,7 +37,7 @@ jobs:
       run: ./Build/invoke-ci-build.ps1 "${{ secrets.GITHUB_TOKEN }}"
 
     - name: Artifact nuget packages
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: nuget-packages
         path: |
@@ -51,9 +51,9 @@ jobs:
     needs: build
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: nuget-packages
         path: build-out
@@ -80,9 +80,9 @@ jobs:
     needs: build
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: nuget-packages
         path: build-out
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install dependencies
       shell: pwsh
@@ -123,7 +123,7 @@ jobs:
       run: ./Build/invoke-benchmarks.ps1 -Configuration "Release"
 
     - name: Artifact results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: benchmark-results
         path: |


### PR DESCRIPTION
Fix warnings in CI build
`node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3 actions/upload-artifact@v3.
For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
`