### PR TITLE
Error handling custom marshaller

### DIFF
--- a/Examples/ErrorHandling/Client/CustomClientFaultDetailDeserializer.cs
+++ b/Examples/ErrorHandling/Client/CustomClientFaultDetailDeserializer.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Contract;
+using ServiceModel.Grpc.Interceptors;
+
+namespace Client;
+
+internal sealed class CustomClientFaultDetailDeserializer : DefaultClientFaultDetailDeserializer
+{
+    public override Type DeserializeDetailType(string typePayload)
+    {
+        if (typePayload == ErrorDetailTypes.UnexpectedErrorDetailTypeName)
+        {
+            return typeof(UnexpectedErrorDetail);
+        }
+
+        return base.DeserializeDetailType(typePayload);
+    }
+}

--- a/Examples/ErrorHandling/Client/Program.cs
+++ b/Examples/ErrorHandling/Client/Program.cs
@@ -17,7 +17,10 @@ public static class Program
         Logger = new SimpleConsoleLogger(),
 
         // combine application and unexpected handlers into one handler
-        ErrorHandler = new ClientErrorHandlerCollection(new ApplicationExceptionClientHandler(), new UnexpectedExceptionClientHandler())
+        ErrorHandler = new ClientErrorHandlerCollection(new ApplicationExceptionClientHandler(), new UnexpectedExceptionClientHandler()),
+
+        // uncomment to fully control ClientFaultDetail.Detail deserialization, must be uncommented in Server as well
+        //ErrorDetailDeserializer = new CustomClientFaultDetailDeserializer()
     });
 
     public static async Task Main()

--- a/Examples/ErrorHandling/ClientDesignTime/CustomClientFaultDetailDeserializer.cs
+++ b/Examples/ErrorHandling/ClientDesignTime/CustomClientFaultDetailDeserializer.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Contract;
+using ServiceModel.Grpc.Interceptors;
+
+namespace ClientDesignTime;
+
+internal sealed class CustomClientFaultDetailDeserializer : DefaultClientFaultDetailDeserializer
+{
+    public override Type DeserializeDetailType(string typePayload)
+    {
+        if (typePayload == ErrorDetailTypes.UnexpectedErrorDetailTypeName)
+        {
+            return typeof(UnexpectedErrorDetail);
+        }
+
+        return base.DeserializeDetailType(typePayload);
+    }
+}

--- a/Examples/ErrorHandling/ClientDesignTime/Program.cs
+++ b/Examples/ErrorHandling/ClientDesignTime/Program.cs
@@ -17,7 +17,10 @@ public static class Program
         Logger = new SimpleConsoleLogger(),
 
         // combine application and unexpected handlers into one handler
-        ErrorHandler = new ClientErrorHandlerCollection(new ApplicationExceptionClientHandler(), new UnexpectedExceptionClientHandler())
+        ErrorHandler = new ClientErrorHandlerCollection(new ApplicationExceptionClientHandler(), new UnexpectedExceptionClientHandler()),
+
+        // uncomment to fully control ClientFaultDetail.Detail deserialization, must be uncommented in Server as well
+        //ErrorDetailDeserializer = new CustomClientFaultDetailDeserializer()
     });
 
     public static async Task Main()

--- a/Examples/ErrorHandling/Contract/ErrorDetailTypes.cs
+++ b/Examples/ErrorHandling/Contract/ErrorDetailTypes.cs
@@ -1,0 +1,6 @@
+﻿namespace Contract;
+
+public static class ErrorDetailTypes
+{
+    public const string UnexpectedErrorDetailTypeName = nameof(UnexpectedErrorDetail);
+}

--- a/Examples/ErrorHandling/ServerAspNetHost/Program.cs
+++ b/Examples/ErrorHandling/ServerAspNetHost/Program.cs
@@ -29,6 +29,9 @@ public static class Program
             .AddServiceModelGrpc(options =>
             {
                 options.DefaultErrorHandlerFactory = serviceProvider => serviceProvider.GetRequiredService<IServerErrorHandler>();
+
+                // uncomment to fully control ServerFaultDetail.Detail serialization, must be uncommented in Client as well
+                //options.DefaultErrorDetailSerializer = new CustomServerFaultDetailSerializer();
             });
 
         builder.WebHost.ConfigureKestrel(options => options.ListenLocalhost(ServiceConfiguration.ServiceModelGrpcPort, l => l.Protocols = HttpProtocols.Http2));

--- a/Examples/ErrorHandling/ServerNativeHost/ServerHost.cs
+++ b/Examples/ErrorHandling/ServerNativeHost/ServerHost.cs
@@ -34,6 +34,9 @@ internal sealed class ServerHost : IHostedService
                 options.ErrorHandler = new ServerErrorHandlerCollection(
                     new ApplicationExceptionServerHandler(),
                     new UnexpectedExceptionServerHandler());
+
+                // uncomment to fully control ServerFaultDetail.Detail serialization, must be uncommented in Client as well
+                //options.ErrorDetailSerializer = new CustomServerFaultDetailSerializer();
             });
     }
 

--- a/Examples/ErrorHandling/Service/CustomServerFaultDetailSerializer.cs
+++ b/Examples/ErrorHandling/Service/CustomServerFaultDetailSerializer.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using Contract;
+using ServiceModel.Grpc.Interceptors;
+
+namespace Service;
+
+public sealed class CustomServerFaultDetailSerializer : DefaultServerFaultDetailSerializer
+{
+    public override string SerializeDetailType(Type detailType)
+    {
+        if (detailType == typeof(UnexpectedErrorDetail))
+        {
+            return ErrorDetailTypes.UnexpectedErrorDetailTypeName;
+        }
+
+        return base.SerializeDetailType(detailType);
+    }
+}

--- a/Sources/ServiceModel.Grpc.AspNetCore/Internal/Binding/PostConfigureGrpcServiceOptions.cs
+++ b/Sources/ServiceModel.Grpc.AspNetCore/Internal/Binding/PostConfigureGrpcServiceOptions.cs
@@ -44,6 +44,7 @@ internal sealed class PostConfigureGrpcServiceOptions : IPostConfigureOptions<Gr
             options.Interceptors,
             _serviceModelOptions.Value.DefaultErrorHandlerFactory,
             _serviceModelOptions.Value.DefaultMarshallerFactory,
+            _serviceModelOptions.Value.DefaultErrorDetailSerializer,
             _loggerFactory);
     }
 
@@ -51,6 +52,7 @@ internal sealed class PostConfigureGrpcServiceOptions : IPostConfigureOptions<Gr
         InterceptorCollection interceptors,
         Func<IServiceProvider, IServerErrorHandler>? errorHandlerFactory,
         IMarshallerFactory? marshallerFactory,
+        IServerFaultDetailSerializer? detailSerializer,
         ILoggerFactory loggerFactory)
     {
         if (errorHandlerFactory != null)
@@ -58,6 +60,7 @@ internal sealed class PostConfigureGrpcServiceOptions : IPostConfigureOptions<Gr
             var args = ErrorHandlerInterceptorFactory.CreateServerHandlerArgs(
                 errorHandlerFactory,
                 marshallerFactory.ThisOrDefault(),
+                detailSerializer,
                 CreateLogger(loggerFactory));
 
             interceptors.Add(ErrorHandlerInterceptorFactory.GetServerHandlerType(), args);

--- a/Sources/ServiceModel.Grpc.AspNetCore/Internal/Binding/PostConfigureGrpcServiceOptions{TService}.cs
+++ b/Sources/ServiceModel.Grpc.AspNetCore/Internal/Binding/PostConfigureGrpcServiceOptions{TService}.cs
@@ -42,11 +42,13 @@ internal sealed class PostConfigureGrpcServiceOptions<TService> : IPostConfigure
     public void PostConfigure(string? name, GrpcServiceOptions<TService> options)
     {
         var marshallerFactory = _serviceConfiguration.Value.MarshallerFactory ?? _rootConfiguration.Value.DefaultMarshallerFactory;
+        var detailMarshaller = _serviceConfiguration.Value.ErrorDetailSerializer ?? _rootConfiguration.Value.DefaultErrorDetailSerializer;
 
         PostConfigureGrpcServiceOptions.AddErrorHandler(
             options.Interceptors,
             _serviceConfiguration.Value.ErrorHandlerFactory,
             marshallerFactory,
+            detailMarshaller,
             _loggerFactory);
     }
 }

--- a/Sources/ServiceModel.Grpc.AspNetCore/ServiceModelGrpcServiceOptions.cs
+++ b/Sources/ServiceModel.Grpc.AspNetCore/ServiceModelGrpcServiceOptions.cs
@@ -40,6 +40,12 @@ public sealed class ServiceModelGrpcServiceOptions
     public Func<IServiceProvider, IServerErrorHandler>? DefaultErrorHandlerFactory { get; set; }
 
     /// <summary>
+    /// Gets or sets an error details serializer, that overrides default serialization.
+    /// It is only applicable with <see cref="DefaultErrorHandlerFactory"/>.
+    /// </summary>
+    public IServerFaultDetailSerializer? DefaultErrorDetailSerializer { get; set; }
+
+    /// <summary>
     /// Gets the collection of globally registered server filters.
     /// </summary>
     public FilterCollection<IServerFilter> Filters

--- a/Sources/ServiceModel.Grpc.AspNetCore/ServiceModelGrpcServiceOptions{TService}.cs
+++ b/Sources/ServiceModel.Grpc.AspNetCore/ServiceModelGrpcServiceOptions{TService}.cs
@@ -42,6 +42,12 @@ public sealed class ServiceModelGrpcServiceOptions<TService>
     public Func<IServiceProvider, IServerErrorHandler>? ErrorHandlerFactory { get; set; }
 
     /// <summary>
+    /// Gets or sets an error details serializer, that overrides default serialization.
+    /// It is only applicable with <see cref="ErrorHandlerFactory"/>.
+    /// </summary>
+    public IServerFaultDetailSerializer? ErrorDetailSerializer { get; set; }
+
+    /// <summary>
     /// Gets the collection of registered server filters for this service.
     /// </summary>
     public FilterCollection<IServerFilter> Filters

--- a/Sources/ServiceModel.Grpc.Interceptors/ClientFaultDetail.cs
+++ b/Sources/ServiceModel.Grpc.Interceptors/ClientFaultDetail.cs
@@ -40,7 +40,7 @@ public readonly struct ClientFaultDetail
     public RpcException OriginalError { get; }
 
     /// <summary>
-    /// Gets the error detail provided by <see cref="IServerErrorHandler"/>.
+    /// Gets the error detail provided by <see cref="IServerErrorHandler"/>, see also <see cref="IClientFaultDetailDeserializer"/>.
     /// </summary>
     public object? Detail { get; }
 }

--- a/Sources/ServiceModel.Grpc.Interceptors/DefaultClientFaultDetailDeserializer.cs
+++ b/Sources/ServiceModel.Grpc.Interceptors/DefaultClientFaultDetailDeserializer.cs
@@ -1,0 +1,47 @@
+﻿// <copyright>
+// Copyright Max Ieremenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using ServiceModel.Grpc.Configuration;
+
+namespace ServiceModel.Grpc.Interceptors;
+
+/// <summary>
+/// The default implementation of <see cref="IClientFaultDetailDeserializer"/>.
+/// </summary>
+public class DefaultClientFaultDetailDeserializer : IClientFaultDetailDeserializer
+{
+    /// <summary>
+    /// The default implementation. <code>Type.GetType(typePayload, true, false)</code>
+    /// </summary>
+    /// <param name="typePayload">A value provided by <see cref="IServerFaultDetailSerializer"/>.<see cref="IServerFaultDetailSerializer.SerializeDetailType"/>.</param>
+    /// <returns>A <see cref="Type"/> of <see cref="ClientFaultDetail.Detail"/>.</returns>
+    public virtual Type DeserializeDetailType(string typePayload) => DeserializeType(typePayload);
+
+    /// <summary>
+    /// The default implementation. <code>marshallerFactory.Marshaller[detailType].Deserialize(detailPayload)</code>
+    /// </summary>
+    /// <param name="marshallerFactory">The current <see cref="IMarshallerFactory"/>.</param>
+    /// <param name="detailType"><see cref="Type"/> of instance, provided by <see cref="DeserializeDetailType"/>.</param>
+    /// <param name="detailPayload">A value provided by <see cref="IServerFaultDetailSerializer"/>.<see cref="IServerFaultDetailSerializer.SerializeDetail"/>.</param>
+    /// <returns>An instance of details.</returns>
+    public virtual object DeserializeDetail(IMarshallerFactory marshallerFactory, Type detailType, byte[] detailPayload) =>
+        Deserialize(marshallerFactory, detailType, detailPayload);
+
+    internal static Type DeserializeType(string typePayload) => Type.GetType(typePayload, true, false)!;
+
+    internal static object Deserialize(IMarshallerFactory marshallerFactory, Type detailType, byte[] detailPayload) =>
+        MarshallerExtensions.DeserializeObject(marshallerFactory, detailType, detailPayload);
+}

--- a/Sources/ServiceModel.Grpc.Interceptors/DefaultServerFaultDetailSerializer.cs
+++ b/Sources/ServiceModel.Grpc.Interceptors/DefaultServerFaultDetailSerializer.cs
@@ -1,0 +1,44 @@
+﻿// <copyright>
+// Copyright Max Ieremenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using ServiceModel.Grpc.Configuration;
+
+namespace ServiceModel.Grpc.Interceptors;
+
+/// <summary>
+/// The default implementation of <see cref="IServerFaultDetailSerializer"/>.
+/// </summary>
+public class DefaultServerFaultDetailSerializer : IServerFaultDetailSerializer
+{
+    /// <summary>
+    /// The default implementation. <code>detailType.AssemblyQualifiedName()</code>.
+    /// </summary>
+    /// <param name="detailType">A type of value, provided by <see cref="ServerFaultDetail"/>.<see cref="ServerFaultDetail.Detail"/>.</param>
+    /// <returns>A string representation of <paramref name="detailType"/>.</returns>
+    public virtual string SerializeDetailType(Type detailType) => SerializeType(detailType);
+
+    /// <summary>
+    /// The default implementation. <code>marshallerFactory.Marshaller[detail.GetType()].Serialize(detail)</code>.
+    /// </summary>
+    /// <param name="marshallerFactory">The current <see cref="IMarshallerFactory"/>.</param>
+    /// <param name="detail">A value, provided by <see cref="ServerFaultDetail"/>.<see cref="ServerFaultDetail.Detail"/>.</param>
+    /// <returns>A byte array representation of <paramref name="detail"/>.</returns>
+    public virtual byte[] SerializeDetail(IMarshallerFactory marshallerFactory, object detail) => Serialize(marshallerFactory, detail);
+
+    internal static string SerializeType(Type detailType) => detailType.GetShortAssemblyQualifiedName();
+
+    internal static byte[] Serialize(IMarshallerFactory marshallerFactory, object detail) => MarshallerExtensions.SerializeObject(marshallerFactory, detail);
+}

--- a/Sources/ServiceModel.Grpc.Interceptors/IClientErrorHandler.cs
+++ b/Sources/ServiceModel.Grpc.Interceptors/IClientErrorHandler.cs
@@ -24,7 +24,7 @@ namespace ServiceModel.Grpc.Interceptors;
 public interface IClientErrorHandler
 {
     /// <summary>
-    /// Handle the exception that was raised by by <see cref="CallInvoker"/>.
+    /// Handle the exception that was raised by <see cref="CallInvoker"/>.
     /// </summary>
     /// <param name="context">The current call context.</param>
     /// <param name="detail">The exception details.</param>

--- a/Sources/ServiceModel.Grpc.Interceptors/IClientFaultDetailDeserializer.cs
+++ b/Sources/ServiceModel.Grpc.Interceptors/IClientFaultDetailDeserializer.cs
@@ -1,0 +1,41 @@
+﻿// <copyright>
+// Copyright Max Ieremenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using ServiceModel.Grpc.Configuration;
+
+namespace ServiceModel.Grpc.Interceptors;
+
+/// <summary>
+/// Allows an implementer to perform custom error details deserialization on client call, <see cref="ClientFaultDetail"/>.<see cref="ClientFaultDetail.Detail"/> and <see cref="ServerFaultDetail"/>.<see cref="ServerFaultDetail.Detail"/>.
+/// </summary>
+public interface IClientFaultDetailDeserializer
+{
+    /// <summary>
+    /// Deserialize <paramref name="typePayload"/> to <see cref="Type"/> of <see cref="ClientFaultDetail.Detail"/>.
+    /// </summary>
+    /// <param name="typePayload">A value provided by <see cref="IServerFaultDetailSerializer"/>.<see cref="IServerFaultDetailSerializer.SerializeDetailType"/>.</param>
+    /// <returns>A <see cref="Type"/> of <see cref="ClientFaultDetail.Detail"/>.</returns>
+    Type DeserializeDetailType(string typePayload);
+
+    /// <summary>
+    /// Deserialize <paramref name="detailPayload"/> to an instance of <see cref="ClientFaultDetail.Detail"/>.
+    /// </summary>
+    /// <param name="marshallerFactory">The current <see cref="IMarshallerFactory"/>.</param>
+    /// <param name="detailType"><see cref="Type"/> of instance, provided by <see cref="DeserializeDetailType"/>.</param>
+    /// <param name="detailPayload">A value provided by <see cref="IServerFaultDetailSerializer"/>.<see cref="IServerFaultDetailSerializer.SerializeDetail"/>.</param>
+    /// <returns>An instance of details.</returns>
+    object DeserializeDetail(IMarshallerFactory marshallerFactory, Type detailType, byte[] detailPayload);
+}

--- a/Sources/ServiceModel.Grpc.Interceptors/IServerFaultDetailSerializer.cs
+++ b/Sources/ServiceModel.Grpc.Interceptors/IServerFaultDetailSerializer.cs
@@ -1,0 +1,40 @@
+﻿// <copyright>
+// Copyright Max Ieremenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using ServiceModel.Grpc.Configuration;
+
+namespace ServiceModel.Grpc.Interceptors;
+
+/// <summary>
+/// Allows an implementer to perform custom error details <see cref="ServerFaultDetail"/>.<see cref="ServerFaultDetail.Detail"/> serialization on server call handler.
+/// </summary>
+public interface IServerFaultDetailSerializer
+{
+    /// <summary>
+    /// Serialize <paramref name="detailType"/> to <see cref="string"/>.
+    /// </summary>
+    /// <param name="detailType">A type of value, provided by <see cref="ServerFaultDetail"/>.<see cref="ServerFaultDetail.Detail"/>.</param>
+    /// <returns>A string representation of <paramref name="detailType"/>.</returns>
+    string SerializeDetailType(Type detailType);
+
+    /// <summary>
+    /// Serialize <paramref name="detail"/> to byte array.
+    /// </summary>
+    /// <param name="marshallerFactory">The current <see cref="IMarshallerFactory"/>.</param>
+    /// <param name="detail">A value, provided by <see cref="ServerFaultDetail"/>.<see cref="ServerFaultDetail.Detail"/>.</param>
+    /// <returns>A byte array representation of <paramref name="detail"/>.</returns>
+    byte[] SerializeDetail(IMarshallerFactory marshallerFactory, object detail);
+}

--- a/Sources/ServiceModel.Grpc.Interceptors/Internal/ErrorHandlerInterceptorFactory.cs
+++ b/Sources/ServiceModel.Grpc.Interceptors/Internal/ErrorHandlerInterceptorFactory.cs
@@ -21,20 +21,32 @@ namespace ServiceModel.Grpc.Interceptors.Internal;
 
 internal static class ErrorHandlerInterceptorFactory
 {
-    public static Interceptor CreateClientHandler(IClientErrorHandler errorHandler, IMarshallerFactory marshallerFactory, ILogger? logger)
+    public static Interceptor CreateClientHandler(
+        IClientErrorHandler errorHandler,
+        IMarshallerFactory marshallerFactory,
+        IClientFaultDetailDeserializer? detailDeserializer,
+        ILogger? logger)
     {
-        var interceptor = new ClientCallErrorInterceptor(errorHandler, marshallerFactory, logger);
+        var interceptor = new ClientCallErrorInterceptor(errorHandler, marshallerFactory, detailDeserializer, logger);
         return new ClientNativeInterceptor(interceptor);
     }
 
-    public static Interceptor CreateServerHandler(IServerErrorHandler errorHandler, IMarshallerFactory marshallerFactory, ILogger? logger)
+    public static Interceptor CreateServerHandler(
+        IServerErrorHandler errorHandler,
+        IMarshallerFactory marshallerFactory,
+        IServerFaultDetailSerializer? detailSerializer,
+        ILogger? logger)
     {
-        var interceptor = new ServerCallErrorInterceptor(errorHandler, marshallerFactory, logger);
+        var interceptor = new ServerCallErrorInterceptor(errorHandler, marshallerFactory, detailSerializer, logger);
         return new ServerNativeInterceptor(interceptor);
     }
 
     public static Type GetServerHandlerType() => typeof(ServerNativeInterceptor);
 
-    public static object CreateServerHandlerArgs(Func<IServiceProvider, IServerErrorHandler> errorHandlerFactory, IMarshallerFactory marshallerFactory, ILogger? logger)
-        => new ErrorHandlerServerCallInterceptorFactory(marshallerFactory, errorHandlerFactory, logger);
+    public static object CreateServerHandlerArgs(
+        Func<IServiceProvider, IServerErrorHandler> errorHandlerFactory,
+        IMarshallerFactory marshallerFactory,
+        IServerFaultDetailSerializer? detailSerializer,
+        ILogger? logger)
+        => new ErrorHandlerServerCallInterceptorFactory(marshallerFactory, detailSerializer, errorHandlerFactory, logger);
 }

--- a/Sources/ServiceModel.Grpc.Interceptors/Internal/ErrorHandlerServerCallInterceptorFactory.cs
+++ b/Sources/ServiceModel.Grpc.Interceptors/Internal/ErrorHandlerServerCallInterceptorFactory.cs
@@ -23,15 +23,18 @@ internal sealed class ErrorHandlerServerCallInterceptorFactory : IServerCallInte
 {
     private readonly IMarshallerFactory _marshallerFactory;
     private readonly Func<IServiceProvider, IServerErrorHandler> _errorHandlerFactory;
+    private readonly IServerFaultDetailSerializer? _detailMarshaller;
     private readonly ILogger? _logger;
 
     public ErrorHandlerServerCallInterceptorFactory(
         IMarshallerFactory marshallerFactory,
+        IServerFaultDetailSerializer? detailMarshaller,
         Func<IServiceProvider, IServerErrorHandler> errorHandlerFactory,
         ILogger? logger)
     {
         _marshallerFactory = GrpcPreconditions.CheckNotNull(marshallerFactory, nameof(marshallerFactory));
         _errorHandlerFactory = GrpcPreconditions.CheckNotNull(errorHandlerFactory, nameof(errorHandlerFactory));
+        _detailMarshaller = detailMarshaller;
         _logger = logger;
     }
 
@@ -40,6 +43,6 @@ internal sealed class ErrorHandlerServerCallInterceptorFactory : IServerCallInte
         GrpcPreconditions.CheckNotNull(serviceProvider, nameof(serviceProvider));
 
         var errorHandler = _errorHandlerFactory(serviceProvider);
-        return new ServerCallErrorInterceptor(errorHandler, _marshallerFactory, _logger);
+        return new ServerCallErrorInterceptor(errorHandler, _marshallerFactory, _detailMarshaller, _logger);
     }
 }

--- a/Sources/ServiceModel.Grpc.Interceptors/ServerFaultDetail.cs
+++ b/Sources/ServiceModel.Grpc.Interceptors/ServerFaultDetail.cs
@@ -24,17 +24,17 @@ namespace ServiceModel.Grpc.Interceptors;
 public struct ServerFaultDetail
 {
     /// <summary>
-    /// Gets or sets the the gRPC status code, <see cref="Status"/>.
+    /// Gets or sets the gRPC status code, <see cref="Status"/>.
     /// </summary>
     public StatusCode? StatusCode { get; set; }
 
     /// <summary>
-    /// Gets or sets the the optional gRPC error message, <see cref="Status"/>.
+    /// Gets or sets the optional gRPC error message, <see cref="Status"/>.
     /// </summary>
     public string? Message { get; set; }
 
     /// <summary>
-    /// Gets or sets the the optional detail of error to pass for a client call.
+    /// Gets or sets the optional detail of error to pass for a client call.
     /// </summary>
     public object? Detail { get; set; }
 

--- a/Sources/ServiceModel.Grpc.SelfHost/Internal/ServiceDefinitionFactory.cs
+++ b/Sources/ServiceModel.Grpc.SelfHost/Internal/ServiceDefinitionFactory.cs
@@ -67,6 +67,7 @@ internal static class ServiceDefinitionFactory
             var errorInterceptor = ErrorHandlerInterceptorFactory.CreateServerHandler(
                 options.ErrorHandler,
                 options.MarshallerFactory.ThisOrDefault(),
+                options.ErrorDetailSerializer,
                 loggerAdapter);
             definition = definition.Intercept(errorInterceptor);
         }

--- a/Sources/ServiceModel.Grpc.SelfHost/ServiceModelGrpcServiceOptions.cs
+++ b/Sources/ServiceModel.Grpc.SelfHost/ServiceModelGrpcServiceOptions.cs
@@ -41,6 +41,12 @@ public sealed class ServiceModelGrpcServiceOptions
     public IServerErrorHandler? ErrorHandler { get; set; }
 
     /// <summary>
+    /// Gets or sets an error details serializer, that overrides default serialization.
+    /// It is only applicable with <see cref="ErrorHandler"/>.
+    /// </summary>
+    public IServerFaultDetailSerializer? ErrorDetailSerializer { get; set; }
+
+    /// <summary>
     /// Gets or sets logger to handle possible output from service binding process.
     /// </summary>
     public ILogger? Logger { get; set; }

--- a/Sources/ServiceModel.Grpc/Client/ClientRegistration.cs
+++ b/Sources/ServiceModel.Grpc/Client/ClientRegistration.cs
@@ -47,6 +47,7 @@ internal sealed class ClientRegistration
             DefaultCallOptionsFactory = defaultOptions?.DefaultCallOptionsFactory,
             Logger = defaultOptions?.Logger,
             ErrorHandler = defaultOptions?.ErrorHandler,
+            ErrorDetailDeserializer = defaultOptions?.ErrorDetailDeserializer,
             ServiceProvider = defaultOptions?.ServiceProvider
         };
 
@@ -66,7 +67,11 @@ internal sealed class ClientRegistration
         Interceptor? interceptor = null;
         if (options.ErrorHandler != null)
         {
-            interceptor = ErrorHandlerInterceptorFactory.CreateClientHandler(options.ErrorHandler, methodBinder.MarshallerFactory, options.Logger);
+            interceptor = ErrorHandlerInterceptorFactory.CreateClientHandler(
+                options.ErrorHandler,
+                methodBinder.MarshallerFactory,
+                options.ErrorDetailDeserializer,
+                options.Logger);
         }
 
         return new ClientRegistration(builder, interceptor);

--- a/Sources/ServiceModel.Grpc/Client/ServiceModelGrpcClientOptions.cs
+++ b/Sources/ServiceModel.Grpc/Client/ServiceModelGrpcClientOptions.cs
@@ -44,6 +44,12 @@ public sealed class ServiceModelGrpcClientOptions
     public IClientErrorHandler? ErrorHandler { get; set; }
 
     /// <summary>
+    /// Gets or sets an error details deserializer, that overrides default deserialization.
+    /// It is only applicable with <see cref="ErrorHandler"/>.
+    /// </summary>
+    public IClientFaultDetailDeserializer? ErrorDetailDeserializer { get; set; }
+
+    /// <summary>
     /// Gets or sets logger to handle possible output from <see cref="IClientFactory"/>.
     /// </summary>
     public ILogger? Logger { get; set; }


### PR DESCRIPTION
Allow to customize error detail serialization/de-serialization

serialization on server
```c#
// see DefaultServerFaultDetailSerializer
public interface IServerFaultDetailSerializer
{
  string SerializeDetailType(Type detailType);
  byte[] SerializeDetail(IMarshallerFactory marshallerFactory, object detail);
}
```

de-serialization on client
```c#
// see DefaultClientFaultDetailDeserializer
public interface IClientFaultDetailDeserializer
{
  Type DeserializeDetailType(string typePayload);
  object DeserializeDetail(IMarshallerFactory marshallerFactory, Type detailType, byte[] detailPayload);
}
```

client factory configuration
```c#
public sealed class ServiceModelGrpcClientOptions
{
  public IClientErrorHandler? ErrorHandler { get; set; }
  public IClientFaultDetailDeserializer? ErrorDetailDeserializer { get; set; } // new property
}
```

asp.net core configuration
```c#
public sealed class ServiceModelGrpcServiceOptions
{
  public Func<IServiceProvider, IServerErrorHandler>? DefaultErrorHandlerFactory { get; set; }
  public IServerFaultDetailSerializer? DefaultErrorDetailSerializer { get; set; } // new property
}

public sealed class ServiceModelGrpcServiceOptions<TService>
{
  public Func<IServiceProvider, IServerErrorHandler>? ErrorHandlerFactory { get; set; }
  public IServerFaultDetailSerializer? ErrorDetailSerializer { get; set; } // new property
}
```

self-host configuration
```c#
public sealed class ServiceModelGrpcServiceOptions
{
   public IServerErrorHandler? ErrorHandler { get; set; }
   public IServerFaultDetailSerializer? ErrorDetailSerializer { get; set; } // new
}
```