### PR TITLE
experimental publicly visible internal API

### DIFF
--- a/Sources/ServiceModel.Grpc.AspNetCore.NSwag.Test/ServiceModel.Grpc.AspNetCore.NSwag.Test.csproj
+++ b/Sources/ServiceModel.Grpc.AspNetCore.NSwag.Test/ServiceModel.Grpc.AspNetCore.NSwag.Test.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>ServiceModel.Grpc.AspNetCore.NSwag</RootNamespace>
-    <AssemblyTitle>ServiceModel.Grpc.AspNetCore.NSwag.Test</AssemblyTitle>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/ServiceModel.Grpc.AspNetCore.Swashbuckle.Test/ServiceModel.Grpc.AspNetCore.Swashbuckle.Test.csproj
+++ b/Sources/ServiceModel.Grpc.AspNetCore.Swashbuckle.Test/ServiceModel.Grpc.AspNetCore.Swashbuckle.Test.csproj
@@ -4,7 +4,6 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>ServiceModel.Grpc.AspNetCore.Swashbuckle</RootNamespace>
-    <AssemblyTitle>ServiceModel.Grpc.AspNetCore.Swashbuckle.Test</AssemblyTitle>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/ServiceModel.Grpc.AspNetCore.Test/ServiceModel.Grpc.AspNetCore.Test.csproj
+++ b/Sources/ServiceModel.Grpc.AspNetCore.Test/ServiceModel.Grpc.AspNetCore.Test.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>ServiceModel.Grpc.AspNetCore</RootNamespace>
-    <AssemblyTitle>ServiceModel.Grpc.AspNetCore.Test</AssemblyTitle>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/ServiceModel.Grpc.AspNetCore/ServiceModel.Grpc.AspNetCore.csproj
+++ b/Sources/ServiceModel.Grpc.AspNetCore/ServiceModel.Grpc.AspNetCore.csproj
@@ -5,6 +5,7 @@
     <AssemblyTitle>ServiceModel.Grpc.AspNetCore</AssemblyTitle>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>true</IsPackable>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">

--- a/Sources/ServiceModel.Grpc.Core.Test/ServiceModel.Grpc.Core.Test.csproj
+++ b/Sources/ServiceModel.Grpc.Core.Test/ServiceModel.Grpc.Core.Test.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>ServiceModel.Grpc</RootNamespace>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/ServiceModel.Grpc.Core/CodeAnalysis/ExperimentalAttribute.cs
+++ b/Sources/ServiceModel.Grpc.Core/CodeAnalysis/ExperimentalAttribute.cs
@@ -14,24 +14,17 @@
 // limitations under the License.
 // </copyright>
 
-using System.ComponentModel;
+namespace System.Diagnostics.CodeAnalysis;
 
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-
-namespace ServiceModel.Grpc.Internal;
-
-/// <summary>
-/// This API supports ServiceModel.Grpc infrastructure and is not intended to be used directly from your code.
-/// This API may change or be removed in future releases.
-/// </summary>
-[Browsable(false)]
-[EditorBrowsable(EditorBrowsableState.Never)]
-[Experimental("ServiceModelGrpcInternalAPI")]
-public interface IStreamAccessor
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, Inherited = false)]
+internal sealed class ExperimentalAttribute : Attribute
 {
-    void Validate(object stream);
+    public ExperimentalAttribute(string diagnosticId)
+    {
+        DiagnosticId = diagnosticId;
+    }
 
-    object CreateEmpty();
+    public string DiagnosticId { get; }
 
-    Type GetInstanceType();
+    public string? UrlFormat { get; set; }
 }

--- a/Sources/ServiceModel.Grpc.Core/Internal/AccessorsFactory.cs
+++ b/Sources/ServiceModel.Grpc.Core/Internal/AccessorsFactory.cs
@@ -27,6 +27,7 @@ namespace ServiceModel.Grpc.Internal;
 /// </summary>
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("ServiceModelGrpcInternalAPI")]
 public static class AccessorsFactory
 {
     public static IStreamAccessor CreateStreamAccessor<TItem>() => StreamAccessor<TItem>.Instance;

--- a/Sources/ServiceModel.Grpc.Core/Internal/CallOptionsBuilder.cs
+++ b/Sources/ServiceModel.Grpc.Core/Internal/CallOptionsBuilder.cs
@@ -34,6 +34,7 @@ namespace ServiceModel.Grpc.Internal;
 /// </summary>
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("ServiceModelGrpcInternalAPI")]
 public ref struct CallOptionsBuilder
 {
     private CallOptions _options;

--- a/Sources/ServiceModel.Grpc.Core/Internal/GrpcMethodFactory.cs
+++ b/Sources/ServiceModel.Grpc.Core/Internal/GrpcMethodFactory.cs
@@ -29,6 +29,7 @@ namespace ServiceModel.Grpc.Internal;
 /// </summary>
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("ServiceModelGrpcInternalAPI")]
 public static class GrpcMethodFactory
 {
     public static IMethod Unary<TRequest, TResponse>(IMarshallerFactory marshallerFactory, string serviceName, string name) =>

--- a/Sources/ServiceModel.Grpc.Core/Internal/IClientCallInvoker.cs
+++ b/Sources/ServiceModel.Grpc.Core/Internal/IClientCallInvoker.cs
@@ -28,6 +28,7 @@ namespace ServiceModel.Grpc.Internal;
 /// </summary>
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("ServiceModelGrpcInternalAPI")]
 public interface IClientCallInvoker
 {
     CallOptionsBuilder CreateOptionsBuilder();

--- a/Sources/ServiceModel.Grpc.Core/Internal/IClientMethodBinder.cs
+++ b/Sources/ServiceModel.Grpc.Core/Internal/IClientMethodBinder.cs
@@ -30,6 +30,7 @@ namespace ServiceModel.Grpc.Internal;
 /// </summary>
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("ServiceModelGrpcInternalAPI")]
 public interface IClientMethodBinder
 {
     /// <exclude />

--- a/Sources/ServiceModel.Grpc.Core/Internal/IMessageAccessor.cs
+++ b/Sources/ServiceModel.Grpc.Core/Internal/IMessageAccessor.cs
@@ -26,6 +26,7 @@ namespace ServiceModel.Grpc.Internal;
 /// </summary>
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("ServiceModelGrpcInternalAPI")]
 public interface IMessageAccessor
 {
     string[] Names { get; }

--- a/Sources/ServiceModel.Grpc.Core/Internal/IOperationDescriptor.cs
+++ b/Sources/ServiceModel.Grpc.Core/Internal/IOperationDescriptor.cs
@@ -27,6 +27,7 @@ namespace ServiceModel.Grpc.Internal;
 /// </summary>
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("ServiceModelGrpcInternalAPI")]
 public interface IOperationDescriptor
 {
     MethodInfo GetContractMethod();

--- a/Sources/ServiceModel.Grpc.Core/Internal/IServiceEndpointBinder.cs
+++ b/Sources/ServiceModel.Grpc.Core/Internal/IServiceEndpointBinder.cs
@@ -31,6 +31,7 @@ namespace ServiceModel.Grpc.Internal;
 /// </summary>
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("ServiceModelGrpcInternalAPI")]
 public interface IServiceEndpointBinder<TService>
 {
     void Bind(IServiceMethodBinder<TService> binder);

--- a/Sources/ServiceModel.Grpc.Core/Internal/IServiceMethodBinder.cs
+++ b/Sources/ServiceModel.Grpc.Core/Internal/IServiceMethodBinder.cs
@@ -34,6 +34,7 @@ namespace ServiceModel.Grpc.Internal;
 /// </summary>
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("ServiceModelGrpcInternalAPI")]
 public interface IServiceMethodBinder<TService>
 {
     IMarshallerFactory MarshallerFactory { get; }

--- a/Sources/ServiceModel.Grpc.Core/Internal/OperationDescriptorBuilder.cs
+++ b/Sources/ServiceModel.Grpc.Core/Internal/OperationDescriptorBuilder.cs
@@ -29,6 +29,7 @@ namespace ServiceModel.Grpc.Internal;
 /// </summary>
 [Browsable(false)]
 [EditorBrowsable(EditorBrowsableState.Never)]
+[Experimental("ServiceModelGrpcInternalAPI")]
 public readonly ref struct OperationDescriptorBuilder
 {
     private readonly bool _isAsync;

--- a/Sources/ServiceModel.Grpc.Core/ServiceModel.Grpc.Core.csproj
+++ b/Sources/ServiceModel.Grpc.Core/ServiceModel.Grpc.Core.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1;net462</TargetFrameworks>
     <RootNamespace>ServiceModel.Grpc</RootNamespace>
     <IsPackable>true</IsPackable>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">

--- a/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.CSharp/CodeGenerators/CompilationUnit.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.CSharp/CodeGenerators/CompilationUnit.cs
@@ -29,6 +29,7 @@ public sealed class CompilationUnit : ICompilationUnit
     {
         AddComment(output);
         AddUsing(output);
+        AddPragma(output);
     }
 
     public void BeginDeclaration(ICodeStringBuilder output, INamedTypeSymbol holder)
@@ -102,5 +103,12 @@ public sealed class CompilationUnit : ICompilationUnit
         output.AppendLine("using System.Threading;");
         output.AppendLine("using System.Threading.Tasks;");
         output.AppendLine();
+    }
+
+    private static void AddPragma(ICodeStringBuilder output)
+    {
+        output
+            .AppendLine("#pragma warning disable ServiceModelGrpcInternalAPI")
+            .AppendLine();
     }
 }

--- a/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.CSharp/ServiceModel.Grpc.DesignTime.CodeAnalysis.CSharp.csproj
+++ b/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.CSharp/ServiceModel.Grpc.DesignTime.CodeAnalysis.CSharp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/ServiceModel.Grpc.Emit.Test/ServiceModel.Grpc.Emit.Test.csproj
+++ b/Sources/ServiceModel.Grpc.Emit.Test/ServiceModel.Grpc.Emit.Test.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>ServiceModel.Grpc.Emit</RootNamespace>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/ServiceModel.Grpc.Emit/ServiceModel.Grpc.Emit.csproj
+++ b/Sources/ServiceModel.Grpc.Emit/ServiceModel.Grpc.Emit.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard2.1;net462</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net462'">

--- a/Sources/ServiceModel.Grpc.Filters.Test/ServiceModel.Grpc.Filters.Test.csproj
+++ b/Sources/ServiceModel.Grpc.Filters.Test/ServiceModel.Grpc.Filters.Test.csproj
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>ServiceModel.Grpc</RootNamespace>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/ServiceModel.Grpc.Filters/ServiceModel.Grpc.Filters.csproj
+++ b/Sources/ServiceModel.Grpc.Filters/ServiceModel.Grpc.Filters.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1;net462</TargetFrameworks>
     <RootNamespace>ServiceModel.Grpc</RootNamespace>
     <IsPackable>true</IsPackable>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">

--- a/Sources/ServiceModel.Grpc.SelfHost.Test/ServiceModel.Grpc.SelfHost.Test.csproj
+++ b/Sources/ServiceModel.Grpc.SelfHost.Test/ServiceModel.Grpc.SelfHost.Test.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TargetFrameworks>net462;net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>ServiceModel.Grpc.SelfHost</RootNamespace>
-    <AssemblyTitle>ServiceModel.Grpc.SelfHost.Test</AssemblyTitle>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Sources/ServiceModel.Grpc.SelfHost/ServiceModel.Grpc.SelfHost.csproj
+++ b/Sources/ServiceModel.Grpc.SelfHost/ServiceModel.Grpc.SelfHost.csproj
@@ -5,6 +5,7 @@
     <AssemblyTitle>ServiceModel.Grpc.SelfHost</AssemblyTitle>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>true</IsPackable>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">

--- a/Sources/ServiceModel.Grpc.Test/ServiceModel.Grpc.Test.csproj
+++ b/Sources/ServiceModel.Grpc.Test/ServiceModel.Grpc.Test.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks>net462;net6.0;net7.0;net8.0</TargetFrameworks>
     <RootNamespace>ServiceModel.Grpc</RootNamespace>
     <AssemblyTitle>ServiceModel.Grpc.Test</AssemblyTitle>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'net462'">

--- a/Sources/ServiceModel.Grpc/ServiceModel.Grpc.csproj
+++ b/Sources/ServiceModel.Grpc/ServiceModel.Grpc.csproj
@@ -5,6 +5,7 @@
     <AssemblyTitle>ServiceModel.Grpc</AssemblyTitle>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <IsPackable>true</IsPackable>
+    <NoWarn>$(NoWarn);ServiceModelGrpcInternalAPI</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' != 'Debug'">


### PR DESCRIPTION
Several types are public through code generation at design time. They change frequently and do not support backward compatibility.

Mark them as [Experimental("ServiceModelGrpcInternalAPI")]

```c#
/// <summary>
/// This API supports ServiceModel.Grpc infrastructure and is not intended to be used directly from your code.
/// This API may change or be removed in future releases.
/// </summary>
[Browsable(false)]
[EditorBrowsable(EditorBrowsableState.Never)]
[Experimental("ServiceModelGrpcInternalAPI")]
public interface IMessageAccessor
{
}
```