### PR TITLE
DesignTime: fix array parameters handling

### DIFF
--- a/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal.Test/Descriptions/OperationDescriptionBuilderTest.Doman.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal.Test/Descriptions/OperationDescriptionBuilderTest.Doman.cs
@@ -94,6 +94,11 @@ public partial class OperationDescriptionBuilderTest
         public Task<(string Value1, int Value2)> TaskValueTuple() => throw new NotSupportedException();
 
         [OperationContract]
+        [ResponseType(typeof(string[]))]
+        [ResponseHeaderNames([])]
+        public Task<string[]> TaskArrayString() => throw new NotSupportedException();
+
+        [OperationContract]
         [ResponseType(typeof(int))]
         [ResponseHeaderNames([])]
         public IAsyncEnumerable<int> AsyncEnumerableInt() => throw new NotSupportedException();
@@ -119,6 +124,12 @@ public partial class OperationDescriptionBuilderTest
         [HeaderResponseType([1], [typeof(int)], 0)]
         [ResponseHeaderNames(["Value"])]
         public ValueTask<(IAsyncEnumerable<string> Stream, int Value)> ValueTaskAsyncEnumerableWithHeader() => throw new NotSupportedException();
+
+        [OperationContract]
+        [ResponseType(typeof(string[]))]
+        [HeaderResponseType([1], [typeof(int[])], 0)]
+        [ResponseHeaderNames(["Values"])]
+        public ValueTask<(IAsyncEnumerable<string[]> Stream, int[] Values)> ValueTaskAsyncEnumerableWithArraysHeader() => throw new NotSupportedException();
     }
 
     [ServiceContract]
@@ -196,6 +207,10 @@ public partial class OperationDescriptionBuilderTest
         public void StringInt(string? value1, int? value2) => throw new NotSupportedException();
 
         [OperationContract]
+        [RequestType([0], [typeof(string[])])]
+        public void StringArray(string[] value) => throw new NotSupportedException();
+
+        [OperationContract]
         [RequestType([0], [typeof(int)])]
         public void AsyncEnumerableInt(IAsyncEnumerable<int> value) => throw new NotSupportedException();
 
@@ -203,6 +218,11 @@ public partial class OperationDescriptionBuilderTest
         [RequestType([2], [typeof(int)])]
         [HeaderRequestType([0, 1], [typeof(int), typeof(string)])]
         public void AsyncEnumerableInt(int value2, string value3, IAsyncEnumerable<int> value1) => throw new NotSupportedException();
+
+        [OperationContract]
+        [RequestType([1], [typeof(int[])])]
+        [HeaderRequestType([0], [typeof(int[])])]
+        public void AsyncEnumerableIntArray(int[] value2, IAsyncEnumerable<int[]> value1) => throw new NotSupportedException();
     }
 
     [AttributeUsage(AttributeTargets.Method)]

--- a/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal.Test/Descriptions/OperationDescriptionBuilderTest.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal.Test/Descriptions/OperationDescriptionBuilderTest.cs
@@ -31,9 +31,9 @@ public partial class OperationDescriptionBuilderTest
     [TestCaseSource(nameof(GetResponseTypeCases))]
     public void ResponseType(
         IMethodSymbol method,
-        INamedTypeSymbol? valueType,
+        ITypeSymbol? valueType,
         int[]? headerIndexes,
-        INamedTypeSymbol[]? headerValueType,
+        ITypeSymbol[]? headerValueType,
         int? streamIndex)
     {
         var actual = Build(method, "s1", "o1");
@@ -45,11 +45,11 @@ public partial class OperationDescriptionBuilderTest
         else
         {
             actual.ResponseType.Properties.Length.ShouldBe(1);
-            var actualValueType = actual.ResponseType.Properties[0].ShouldBeAssignableTo<INamedTypeSymbol>().ShouldNotBeNull();
+            var actualValueType = actual.ResponseType.Properties[0].ShouldBeAssignableTo<ITypeSymbol>().ShouldNotBeNull();
             if (valueType.IsTupleType)
             {
                 actualValueType.IsTupleType.ShouldBeTrue();
-                actualValueType.TupleUnderlyingType.ShouldBe(valueType, SymbolEqualityComparer.Default);
+                ((INamedTypeSymbol)actualValueType).TupleUnderlyingType.ShouldBe(valueType, SymbolEqualityComparer.Default);
             }
             else
             {
@@ -93,9 +93,9 @@ public partial class OperationDescriptionBuilderTest
     public void RequestType(
         IMethodSymbol method,
         int[] requestIndexes,
-        INamedTypeSymbol[] requestValueType,
+        ITypeSymbol[] requestValueType,
         int[] headerIndexes,
-        INamedTypeSymbol[]? headerValueType)
+        ITypeSymbol[]? headerValueType)
     {
         var actual = Build(method, "s1", "o1");
 
@@ -165,7 +165,7 @@ public partial class OperationDescriptionBuilderTest
                 method,
                 response.ConstructorArguments[0].Value,
                 responseHeader?.ConstructorArguments[0].Values.Select(i => (int)i.Value!).ToArray(),
-                responseHeader?.ConstructorArguments[1].Values.Select(i => (INamedTypeSymbol)i.Value!).ToArray(),
+                responseHeader?.ConstructorArguments[1].Values.Select(i => (ITypeSymbol)i.Value!).ToArray(),
                 responseHeader?.ConstructorArguments[2].Value)
             {
                 TestName = "ResponseType." + method.Name
@@ -201,9 +201,9 @@ public partial class OperationDescriptionBuilderTest
             yield return new TestCaseData(
                 method,
                 request.ConstructorArguments[0].Values.Select(i => (int)i.Value!).ToArray(),
-                request.ConstructorArguments[1].Values.Select(i => (INamedTypeSymbol)i.Value!).ToArray(),
+                request.ConstructorArguments[1].Values.Select(i => (ITypeSymbol)i.Value!).ToArray(),
                 headerRequest?.ConstructorArguments[0].Values.Select(i => (int)i.Value!).ToArray(),
-                headerRequest?.ConstructorArguments[1].Values.Select(i => (INamedTypeSymbol)i.Value!).ToArray())
+                headerRequest?.ConstructorArguments[1].Values.Select(i => (ITypeSymbol)i.Value!).ToArray())
             {
                 TestName = "RequestType." + method.Name
             };

--- a/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal/Descriptions/Reflection/ReflectTypeSymbol.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal/Descriptions/Reflection/ReflectTypeSymbol.cs
@@ -67,7 +67,12 @@ internal sealed class ReflectTypeSymbol : IReflect<ITypeSymbol>
 
     public ITypeSymbol[] GenericTypeArguments(ITypeSymbol type)
     {
-        var args = ((INamedTypeSymbol)type).TypeArguments;
+        if (type is not INamedTypeSymbol typeSymbol || typeSymbol.TypeArguments.Length == 0)
+        {
+            return [];
+        }
+
+        var args = typeSymbol.TypeArguments;
         var result = new ITypeSymbol[args.Length];
         args.CopyTo(result);
         return result;


### PR DESCRIPTION
in the following case, the c# codegenrator fails with InvalidCastException

```c#
class SomeObject {}

[OperationContract]
Task<SomeObject[]> DoSomething(....);
```