### PR TITLE
benchmarks update dependencies

### DIFF
--- a/Benchmarks/Directory.Packages.props
+++ b/Benchmarks/Directory.Packages.props
@@ -3,11 +3,11 @@
 
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="MagicOnion" Version="6.1.4" />
-    <PackageVersion Include="MagicOnion.Server" Version="6.1.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.8" />
-    <PackageVersion Include="protobuf-net.Grpc" Version="1.1.1" />
-    <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.1.1" />
-    <PackageVersion Include="System.ServiceModel.Primitives" Version="8.0.0" />
+    <PackageVersion Include="MagicOnion" Version="6.1.6" />
+    <PackageVersion Include="MagicOnion.Server" Version="6.1.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.0" />
+    <PackageVersion Include="protobuf-net.Grpc" Version="1.2.2" />
+    <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
+    <PackageVersion Include="System.ServiceModel.Primitives" Version="8.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- MagicOnion 6.1.4 => 6.1.6
- MagicOnion.Server 6.1.4 => 6.1.6
- Microsoft.AspNetCore.TestHost 8.0.8 => 9.0.0
- protobuf-net.Grpc 1.1.1 => 1.2.2
- protobuf-net.Grpc.AspNetCore 1.1.1 => 1.2.2
- System.ServiceModel.Primitives 8.0.0 => 8.1.0