### PR TITLE
fix object parameter handling

### DIFF
--- a/Sources/ServiceModel.Grpc.Descriptions/OperationDescriptionBuilder.cs
+++ b/Sources/ServiceModel.Grpc.Descriptions/OperationDescriptionBuilder.cs
@@ -89,18 +89,32 @@ internal readonly ref struct OperationDescriptionBuilder<TType>
 
     private static MessageDescription<TType> CreateMessage(params TType[] properties) => new(properties);
 
-    private bool IsContextParameter(TType type) =>
-        _reflect.IsAssignableFrom(type, typeof(ServerCallContext))
-        || _reflect.IsAssignableFrom(type, typeof(CancellationToken))
-        || _reflect.IsAssignableFrom(type, typeof(CancellationToken?))
-        || _reflect.IsAssignableFrom(type, typeof(CallContext))
-        || _reflect.IsAssignableFrom(type, typeof(CallOptions))
-        || _reflect.IsAssignableFrom(type, typeof(CallOptions?));
+    private bool IsContextParameter(TType type)
+    {
+        if (_reflect.Equals(type, typeof(object)))
+        {
+            return false;
+        }
 
-    private bool IsDataParameter(TType type) =>
-        !_reflect.IsTaskOrValueTask(type)
-        && !IsContextParameter(type)
-        && !_reflect.IsAssignableFrom(type, typeof(Stream));
+        return _reflect.IsAssignableFrom(type, typeof(ServerCallContext))
+               || _reflect.IsAssignableFrom(type, typeof(CancellationToken))
+               || _reflect.IsAssignableFrom(type, typeof(CancellationToken?))
+               || _reflect.IsAssignableFrom(type, typeof(CallContext))
+               || _reflect.IsAssignableFrom(type, typeof(CallOptions))
+               || _reflect.IsAssignableFrom(type, typeof(CallOptions?));
+    }
+
+    private bool IsDataParameter(TType type)
+    {
+        if (_reflect.Equals(type, typeof(object)))
+        {
+            return true;
+        }
+
+        return !_reflect.IsTaskOrValueTask(type)
+               && !IsContextParameter(type)
+               && !_reflect.IsAssignableFrom(type, typeof(Stream));
+    }
 
     private bool TryCreateResponseType(
         out MessageDescription<TType> responseType,
@@ -115,7 +129,7 @@ internal readonly ref struct OperationDescriptionBuilder<TType>
         headerIndexes = [];
         errorDetails = null;
 
-        if (_reflect.IsAssignableFrom(_method.ReturnType, typeof(void)))
+        if (_reflect.Equals(_method.ReturnType, typeof(void)))
         {
             return true;
         }

--- a/Sources/ServiceModel.Grpc.Descriptions/Reflection/IReflect.cs
+++ b/Sources/ServiceModel.Grpc.Descriptions/Reflection/IReflect.cs
@@ -32,6 +32,8 @@ internal interface IReflect<TType>
 
     bool Equals(TType x, TType y);
 
+    bool Equals(TType x, Type y);
+
     bool IsTaskOrValueTask(TType type);
 
     TType[] GenericTypeArguments(TType type);

--- a/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal.Test/Descriptions/OperationDescriptionBuilderTest.Doman.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal.Test/Descriptions/OperationDescriptionBuilderTest.Doman.cs
@@ -69,6 +69,11 @@ public partial class OperationDescriptionBuilderTest
         public string String() => throw new NotSupportedException();
 
         [OperationContract]
+        [ResponseType(typeof(object))]
+        [ResponseHeaderNames([])]
+        public object Object() => throw new NotSupportedException();
+
+        [OperationContract]
         [ResponseType(typeof(ValueTuple<string, int>))]
         [ResponseHeaderNames([])]
         public (string Value1, int Value2) ValueTuple() => throw new NotSupportedException();
@@ -203,6 +208,10 @@ public partial class OperationDescriptionBuilderTest
         public void Int(int value) => throw new NotSupportedException();
 
         [OperationContract]
+        [RequestType([0], [typeof(object)])]
+        public void Object(object value) => throw new NotSupportedException();
+
+        [OperationContract]
         [RequestType([0, 1], [typeof(string), typeof(int?)])]
         public void StringInt(string? value1, int? value2) => throw new NotSupportedException();
 
@@ -251,6 +260,10 @@ public partial class OperationDescriptionBuilderTest
         [OperationContract]
         [ContextInput([1])]
         public void CallContext(int value1, CallContext value2) => throw new NotSupportedException();
+
+        [OperationContract]
+        [ContextInput([1])]
+        public void CallContextWithObject(object value1, CallContext? value2) => throw new NotSupportedException();
 
         [OperationContract]
         [ContextInput([0])]

--- a/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal/Descriptions/Reflection/ReflectTypeSymbol.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal/Descriptions/Reflection/ReflectTypeSymbol.cs
@@ -63,6 +63,8 @@ internal sealed class ReflectTypeSymbol : IReflect<ITypeSymbol>
 
     public bool Equals(ITypeSymbol x, ITypeSymbol y) => SymbolEqualityComparer.Default.Equals(x, y);
 
+    public bool Equals(ITypeSymbol x, Type y) => x.Is(y);
+
     public bool IsTaskOrValueTask(ITypeSymbol type) => SyntaxTools.IsTask(type) || type.IsValueTask();
 
     public ITypeSymbol[] GenericTypeArguments(ITypeSymbol type)

--- a/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis/SyntaxTools.cs
+++ b/Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis/SyntaxTools.cs
@@ -562,6 +562,11 @@ public static class SyntaxTools
             return "void";
         }
 
+        if (nameof(Object).Equals(name, StringComparison.Ordinal))
+        {
+            return "object";
+        }
+
         return name;
     }
 }

--- a/Sources/ServiceModel.Grpc.Emit.Test/Descriptions/OperationDescriptionBuilderTest.Domain.cs
+++ b/Sources/ServiceModel.Grpc.Emit.Test/Descriptions/OperationDescriptionBuilderTest.Domain.cs
@@ -70,6 +70,10 @@ public partial class OperationDescriptionBuilderTest
         public string String() => throw new NotSupportedException();
 
         [OperationContract]
+        [ResponseType(typeof(Message<object>))]
+        public object Object() => throw new NotSupportedException();
+
+        [OperationContract]
         [ResponseType(typeof(Message<(string, int)>))]
         public (string Value1, int Value2) ValueTuple() => throw new NotSupportedException();
 
@@ -195,6 +199,10 @@ public partial class OperationDescriptionBuilderTest
         public void Int(int value) => throw new NotSupportedException();
 
         [OperationContract]
+        [RequestType(typeof(Message<object>), [0])]
+        public void Object(object value) => throw new NotSupportedException();
+
+        [OperationContract]
         [RequestType(typeof(Message<string, int?>), [0, 1])]
         public void StringInt(string value1, int? value2) => throw new NotSupportedException();
 
@@ -237,6 +245,10 @@ public partial class OperationDescriptionBuilderTest
         [OperationContract]
         [ContextInput([1])]
         public void CallContext(int value1, CallContext value2) => throw new NotSupportedException();
+
+        [OperationContract]
+        [ContextInput([1])]
+        public void CallContextWithObject(object value1, CallContext? value2) => throw new NotSupportedException();
 
         [OperationContract]
         [ContextInput([0])]

--- a/Sources/ServiceModel.Grpc.TestApi/ClientBuilderTestBase.cs
+++ b/Sources/ServiceModel.Grpc.TestApi/ClientBuilderTestBase.cs
@@ -102,7 +102,7 @@ public abstract class ClientBuilderTestBase
     }
 
     [Test]
-    public void ReturnStringContext()
+    public void ReturnString()
     {
         TestOutput.WriteLine(GetClientInstanceMethod(nameof(IContract.ReturnString)).Disassemble());
 
@@ -111,6 +111,21 @@ public abstract class ClientBuilderTestBase
         var actual = Factory().ReturnString();
 
         actual.ShouldBe("a");
+        CallInvoker.VerifyAll();
+    }
+
+    [Test]
+    public void ReturnObject()
+    {
+        TestOutput.WriteLine(GetClientInstanceMethod(nameof(IContract.ReturnObject)).Disassemble());
+
+        var request = new object();
+        var response = new object();
+        CallInvoker.SetupBlockingUnaryCallInOut(request, response);
+
+        var actual = Factory().ReturnObject(request);
+
+        actual.ShouldBe(response);
         CallInvoker.VerifyAll();
     }
 

--- a/Sources/ServiceModel.Grpc.TestApi/Domain/IContract.cs
+++ b/Sources/ServiceModel.Grpc.TestApi/Domain/IContract.cs
@@ -41,6 +41,9 @@ public interface IContract : IDisposable
     string ReturnString();
 
     [OperationContract]
+    object ReturnObject(object value);
+
+    [OperationContract]
     Task<string> ReturnStringAsync(ServerCallContext? context = default);
 
     [OperationContract]

--- a/Sources/ServiceModel.Grpc.TestApi/ServiceEndpointBuilderTestBase.cs
+++ b/Sources/ServiceModel.Grpc.TestApi/ServiceEndpointBuilderTestBase.cs
@@ -173,6 +173,26 @@ public abstract class ServiceEndpointBuilderTestBase
     }
 
     [Test]
+    public async Task ReturnObject()
+    {
+        var call = ChannelType
+            .InstanceMethod(nameof(IContract.ReturnObject))
+            .CreateDelegate<Func<IContract, Message<object>, ServerCallContext, Task<Message<object>>>>(Channel);
+        TestOutput.WriteLine(call.Method.Disassemble());
+
+        var request = new object();
+        var response = new object();
+        _service
+            .Setup(s => s.ReturnObject(request))
+            .Returns(response);
+
+        var actual = await call(_service.Object, new Message<object>(request), null!).ConfigureAwait(false);
+
+        actual.Value1.ShouldBe(response);
+        _service.VerifyAll();
+    }
+
+    [Test]
     public async Task ReturnStringAsync()
     {
         var call = ChannelType


### PR DESCRIPTION
The following operation definition leads to `System.ArgumentOutOfRangeException: Specified argument was out of the range of valid values. (Parameter 'CallOptionsBuilder does not implement method WithObject.')` on building a proxy for client calls

```c#
 [OperationContract]
Task DoSomething(object value);
```

The exception message states that the `value` parameter was recognized as `context` parameter (like CancellationToken, CallContext, etc).

A `System.Object` parameter or return type should be considered a `data` parameter. The following cases are valid ones and should be handlined correctly

```c#
object Do(object value);
void Do(object value);
object Do();
Task<object> Do();
ValueTask<object> Do();
```
