### PR TITLE
non-grpc response handling in SwaggerUiMiddleware

### DIFF
--- a/Sources/ServiceModel.Grpc.AspNetCore.TestApi/Domain/CustomResponseMiddleware.cs
+++ b/Sources/ServiceModel.Grpc.AspNetCore.TestApi/Domain/CustomResponseMiddleware.cs
@@ -1,0 +1,41 @@
+﻿// <copyright>
+// Copyright Max Ieremenko
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Net;
+
+namespace ServiceModel.Grpc.AspNetCore.TestApi.Domain;
+
+public sealed class CustomResponseMiddleware : IMiddleware
+{
+    public const string HeaderResponseStatusCode = "CustomStatusCode";
+    public const string HeaderContentType = "CustomContentType";
+    public const string HeaderResponseBody = "CustomBody";
+
+    public Task InvokeAsync(HttpContext context, RequestDelegate next)
+    {
+        var statusCode = context.Request.Headers[HeaderResponseStatusCode];
+        if (statusCode.Count == 0)
+        {
+            return next(context);
+        }
+
+        context.Response.StatusCode = (int)Enum.Parse<HttpStatusCode>(statusCode.ToString());
+        context.Response.ContentType = context.Request.Headers[HeaderContentType].ToString();
+
+        var body = context.Request.Headers[HeaderResponseBody].ToString();
+        return context.Response.BodyWriter.WriteAsync(Encoding.UTF8.GetBytes(body)).AsTask();
+    }
+}

--- a/Sources/ServiceModel.Grpc.AspNetCore.TestApi/SwaggerUiClient.cs
+++ b/Sources/ServiceModel.Grpc.AspNetCore.TestApi/SwaggerUiClient.cs
@@ -37,81 +37,74 @@ public sealed class SwaggerUiClient
 
     public async Task<HttpResponseHeaders> InvokeAsync(string methodName, IDictionary<string, object> parameters, IDictionary<string, string>? headers = null)
     {
-        var endpoint = _document.GetEndpoint(_serviceName, methodName);
-        var contentType = _document.GetRequestContentType(endpoint);
-        var url = new Uri(new Uri(_hostLocation), endpoint);
+        var response = await PostAsync(methodName, parameters, headers).ConfigureAwait(false);
 
-        using (var client = new HttpClient())
-        {
-            HttpResponseMessage response;
-
-            using (var request = new MemoryStream())
-            {
-                using (var writer = new StreamWriter(request, leaveOpen: true))
-                {
-                    JsonSerializer.CreateDefault().Serialize(writer, parameters);
-                }
-
-                request.Position = 0;
-                using (var content = new StreamContent(request))
-                {
-                    content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
-                    if (headers != null)
-                    {
-                        foreach (var entry in headers)
-                        {
-                            content.Headers.Add(entry.Key, entry.Value);
-                        }
-                    }
-
-                    response = await client.PostAsync(url, content).ConfigureAwait(false);
-                }
-            }
-
-            response.EnsureSuccessStatusCode();
-            return response.Headers;
-        }
+        response.EnsureSuccessStatusCode();
+        return response.Headers;
     }
 
     public async Task<T> InvokeAsync<T>(string methodName, IDictionary<string, object> parameters, IDictionary<string, string>? headers = null)
+    {
+        var response = await PostAsync(methodName, parameters, headers).ConfigureAwait(false);
+
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
+        return JsonSerializer.CreateDefault().Deserialize<T>(new JsonTextReader(new StreamReader(content)))!;
+    }
+
+    public async Task<HttpResponseMessage> PostAsync(string methodName, IDictionary<string, object>? parameters = null, IDictionary<string, string>? headers = null)
     {
         var endpoint = _document.GetEndpoint(_serviceName, methodName);
         var contentType = _document.GetRequestContentType(endpoint);
         var url = new Uri(new Uri(_hostLocation), endpoint);
 
-        using (var client = new HttpClient())
+        using var client = new HttpClient();
+
+        using var requestBody = new MemoryStream();
+        using (var writer = new StreamWriter(requestBody, leaveOpen: true))
         {
-            HttpResponseMessage response;
-
-            using (var request = new MemoryStream())
-            {
-                using (var writer = new StreamWriter(request, leaveOpen: true))
-                {
-                    JsonSerializer.CreateDefault().Serialize(writer, parameters);
-                }
-
-                request.Position = 0;
-                using (var content = new StreamContent(request))
-                {
-                    content.Headers.ContentType = new MediaTypeHeaderValue(contentType);
-                    if (headers != null)
-                    {
-                        foreach (var entry in headers)
-                        {
-                            content.Headers.Add(entry.Key, entry.Value);
-                        }
-                    }
-
-                    response = await client.PostAsync(url, content).ConfigureAwait(false);
-                }
-            }
-
-            response.EnsureSuccessStatusCode();
-
-            using (var content = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
-            {
-                return JsonSerializer.CreateDefault().Deserialize<T>(new JsonTextReader(new StreamReader(content)))!;
-            }
+            JsonSerializer.CreateDefault().Serialize(writer, parameters);
         }
+
+        HttpResponseMessage response;
+
+        requestBody.Position = 0;
+        using (var request = new StreamContent(requestBody))
+        {
+            request.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+            if (headers != null)
+            {
+                foreach (var entry in headers)
+                {
+                    request.Headers.Add(entry.Key, entry.Value);
+                }
+            }
+
+            response = await client.PostAsync(url, request).ConfigureAwait(false);
+        }
+
+        var result = new HttpResponseMessage(response.StatusCode);
+        foreach (var header in response.Headers)
+        {
+            result.Headers.Add(header.Key, header.Value);
+        }
+
+        var responseBody = new MemoryStream();
+        await using (var content = await response.Content.ReadAsStreamAsync().ConfigureAwait(false))
+        {
+            await content.CopyToAsync(responseBody).ConfigureAwait(false);
+        }
+
+        responseBody.Position = 0;
+        result.Content = new StreamContent(responseBody)
+        {
+            Headers =
+            {
+                ContentType = response.Content.Headers.ContentType
+            }
+        };
+
+        return result;
     }
 }

--- a/Sources/ServiceModel.Grpc.AspNetCore/Internal/Swagger/SwaggerUiMiddleware.cs
+++ b/Sources/ServiceModel.Grpc.AspNetCore/Internal/Swagger/SwaggerUiMiddleware.cs
@@ -110,6 +110,18 @@ internal sealed class SwaggerUiMiddleware
             response = await proxy.GetResponseBody().ConfigureAwait(false);
         }
 
+        // non GRPC response => pass as is
+        if (context.Response.StatusCode != (int)HttpStatusCode.OK
+            || !ProtocolConstants.MediaTypeNameGrpc.Equals(context.Response.Headers.ContentType, StringComparison.OrdinalIgnoreCase))
+        {
+            if (response.Length > 0)
+            {
+                await response.CopyToAsync(context.Response.BodyWriter.AsStream(true), context.RequestAborted).ConfigureAwait(false);
+            }
+
+            return;
+        }
+
         context.Response.ContentType = ProtocolConstants.MediaTypeNameSwaggerResponse;
         if (status.StatusCode == StatusCode.OK)
         {


### PR DESCRIPTION
It is related to #301. SwaggerUiMiddleware should return non-grpc response as is.

How to reproduce:

enable authentication and register the service in the following way. Invoke any method from Swagger UI

```c#
// SwaggerUiMiddleware accepts an unauthenticated request first
app.UseServiceModelGrpcSwaggerGateway();

// then pass it to authentication middleware
app.UseAuthentication();

// the unauthenticated request will never reach here, because of authentication middleware
app.MapGrpcService<SomeService>();

[Authorize]
public class SomeService;
```

In the provided example `UseAuthentication` returns `401` and `SwaggerUiMiddleware` should not handle the response.