### PR TITLE
#307: blazor publish, fix trimming issues

### DIFF
--- a/Sources/ServiceModel.Grpc.Emit/CodeGenerators/EmitClientBuilder.cs
+++ b/Sources/ServiceModel.Grpc.Emit/CodeGenerators/EmitClientBuilder.cs
@@ -309,6 +309,7 @@ internal sealed class EmitClientBuilder
         body.Emit(OpCodes.Ret);
     }
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods, typeof(CallOptionsBuilder))]
     private void InitializeCallOptionsBuilder(ILGenerator body, OperationDescription<Type> operation)
     {
         // var optionsBuilder = _clientCallInvoker.CreateOptionsBuilder();

--- a/Sources/ServiceModel.Grpc.Emit/CodeGenerators/EmitClientBuilderBuilder.cs
+++ b/Sources/ServiceModel.Grpc.Emit/CodeGenerators/EmitClientBuilderBuilder.cs
@@ -42,6 +42,7 @@ internal sealed class EmitClientBuilderBuilder
     }
 
     [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(IClientBuilder<>))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(IClientMethodBinder))]
     [UnconditionalSuppressMessage("Trimming", "IL2077:TypeBuilder.AddInterfaceImplementation")]
     public TypeInfo Build(ModuleBuilder moduleBuilder, string? className = default)
     {

--- a/Sources/ServiceModel.Grpc.Emit/CodeGenerators/ReflectDescriptor.cs
+++ b/Sources/ServiceModel.Grpc.Emit/CodeGenerators/ReflectDescriptor.cs
@@ -23,6 +23,7 @@ internal sealed class ReflectDescriptor
 {
     private readonly Dictionary<int, object> _createMessageAccessor;
 
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicMethods, typeof(OperationDescriptorBuilder))]
     public ReflectDescriptor()
     {
         FuncMethodInfoCtor = typeof(Func<MethodInfo>).Constructor(2);


### PR DESCRIPTION
The fix is related to #307.
Introduced hints for the [trimming](https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/configure-trimmer?view=aspnetcore-9.0) process to avoid removing necessary dependencies.