### PR TITLE
fix sdk installation path

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
   sdk-test-linux:
     name: linux-sdk-test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
 
     steps:
@@ -105,7 +105,7 @@ jobs:
 
   benchmarks:
     name: linux-benchmarks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v4

--- a/Build/scripts/Install-DotNet.ps1
+++ b/Build/scripts/Install-DotNet.ps1
@@ -27,6 +27,21 @@ function Test-Version {
     }
 }
 
+function Get-InstallationPath {
+    if (Get-Command -Name dotnet -ErrorAction SilentlyContinue) {
+        $versions = dotnet --list-sdks
+        foreach ($installedVersion in $versions) {
+            $path = ($installedVersion -split ' ')[1]
+            $path = $path.Trim('[', ']')
+            if (Test-Path $path) {
+                return  (Split-Path -Path $path -Parent)
+            }
+        }
+    }
+
+    $IsLinux ? '/usr/share/dotnet' : 'C:\Program Files\dotnet'
+}
+
 if (Get-Command -Name dotnet -ErrorAction SilentlyContinue) {
     $versions = dotnet --list-sdks
     foreach ($installedVersion in $versions) {
@@ -34,17 +49,16 @@ if (Get-Command -Name dotnet -ErrorAction SilentlyContinue) {
         $test = ($installedVersion -split ' ')[0]
     
         if (Test-Version -Target $Version -Test $test) {
-            Write-Output ".net sdk $test is alredy installed"
+            Write-Output ".net sdk $test is already installed"
             return
         }
     }
 }
 
-$installDir = 'C:\Program Files\dotnet'
+$installDir = Get-InstallationPath
 $installScript = 'dotnet-install.ps1'
 
 if ($IsLinux) {
-    $installDir = '/usr/share/dotnet'
     $installScript = 'dotnet-install.sh'
 }
 


### PR DESCRIPTION
The default .net sdk installation path on `ubuntu-latest` changed from /usr/share/dotnet to  /usr/lib/dotnet