### PR TITLE
avoid Reflection.Emit at runtime in the browser

### DIFF
--- a/Examples/BlazorApp/Client/BlazorApp.Client.csproj
+++ b/Examples/BlazorApp/Client/BlazorApp.Client.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" PrivateAssets="all" />
-    <PackageReference Include="ServiceModel.Grpc" />
+    <PackageReference Include="ServiceModel.Grpc.DesignTime" />
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="Grpc.Net.Client.Web" />
   </ItemGroup>

--- a/Examples/BlazorApp/Client/GrpcClients.cs
+++ b/Examples/BlazorApp/Client/GrpcClients.cs
@@ -1,0 +1,16 @@
+﻿using BlazorApp.Shared;
+using ServiceModel.Grpc.Client;
+using ServiceModel.Grpc.DesignTime;
+
+namespace BlazorApp.Client;
+
+// instruct ServiceModel.Grpc.DesignTime to generate required code during the build process
+[ImportGrpcService(typeof(IWeatherForecastService))]
+internal static partial class GrpcClients
+{
+    // register generated IWeatherForecastService client to avoid Reflection.Emit at runtime in the browser
+    public static void AddAllClients(IClientFactory clientFactory)
+    {
+        clientFactory.AddWeatherForecastServiceClient();
+    }
+}

--- a/Examples/BlazorApp/Client/Program.cs
+++ b/Examples/BlazorApp/Client/Program.cs
@@ -32,7 +32,14 @@ public static class Program
         });
 
         // register ClientFactory
-        services.AddSingleton<IClientFactory>(_ => new ClientFactory());
+        services.AddSingleton<IClientFactory>(_ =>
+        {
+            var factory = new ClientFactory();
+
+            GrpcClients.AddAllClients(factory);
+
+            return factory;
+        });
 
         // resolve IWeatherForecastService from ClientFactory
         services.AddScoped(provider =>


### PR DESCRIPTION
Blazor WebAssembly performs IL trimming to reduce the size of the published output. [Trimming](https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/configure-trimmer?view=aspnetcore-9.0) occurs when publishing an app.

To avoid Reflection.Emit at runtime in the browser and trimming issues, the example is adapted to generate the required code during the build process.

