### PR TITLE
avoid Reflection.Emit at runtime in the browser

### DIFF
--- a/Examples/SimpleChat/SimpleChat.Client.Shared/Internal/GrpcClients.cs
+++ b/Examples/SimpleChat/SimpleChat.Client.Shared/Internal/GrpcClients.cs
@@ -1,0 +1,9 @@
+﻿using ServiceModel.Grpc.DesignTime;
+using SimpleChat.Shared;
+
+namespace SimpleChat.Client.Shared.Internal;
+
+// instruct ServiceModel.Grpc.DesignTime to generate required code during the build process
+[ImportGrpcService(typeof(IChatService), GenerateDependencyInjectionExtensions = true)]
+[ImportGrpcService(typeof(IAccountService), GenerateDependencyInjectionExtensions = true)]
+internal static partial class GrpcClients;

--- a/Examples/SimpleChat/SimpleChat.Client.Shared/ServiceCollectionExtensions.cs
+++ b/Examples/SimpleChat/SimpleChat.Client.Shared/ServiceCollectionExtensions.cs
@@ -44,8 +44,9 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IJwtTokenProvider, JwtTokenProvider>();
 
         services
-            .AddServiceModelGrpcClient<IChatService>()
-            .AddServiceModelGrpcClient<IAccountService>();
+            .AddServiceModelGrpcClientFactory()
+            .AddChatServiceClient() // register generated IChatService client to avoid Reflection.Emit at runtime in the browser
+            .AddAccountServiceClient(); // register generated IAccountService client to avoid Reflection.Emit at runtime in the browser
 
         services.AddTransient<IChatClientRoom, ChatClientRoom>();
     }

--- a/Examples/SimpleChat/SimpleChat.Client.Shared/SimpleChat.Client.Shared.csproj
+++ b/Examples/SimpleChat/SimpleChat.Client.Shared/SimpleChat.Client.Shared.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ServiceModel.Grpc" />
+    <PackageReference Include="ServiceModel.Grpc.DesignTime" />
     <PackageReference Include="ServiceModel.Grpc.Client.DependencyInjection" />
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="Grpc.Net.Client.Web" />


### PR DESCRIPTION
Blazor WebAssembly performs IL trimming to reduce the size of the published output. [Trimming](https://learn.microsoft.com/en-us/aspnet/core/blazor/host-and-deploy/configure-trimmer?view=aspnetcore-9.0) occurs when publishing an app.

To avoid Reflection.Emit at runtime in the browser and trimming issues, the example is adapted to generate the required code during the build process.