### PR TITLE
'sudo dotnet-install.sh' on ubuntu-24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
 
   sdk-test-linux:
     name: linux-sdk-test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     needs: build
 
     steps:
@@ -105,7 +105,7 @@ jobs:
 
   benchmarks:
     name: linux-benchmarks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/Build/scripts/Install-DotNet.ps1
+++ b/Build/scripts/Install-DotNet.ps1
@@ -77,4 +77,9 @@ if ($IsLinux) {
 }
 
 "$dotnetInstall -Version $Version -InstallDir $installDir"
-& $dotnetInstall -Version $Version -InstallDir $installDir
+if ($IsLinux -and (Get-Command -Name sudo -ErrorAction SilentlyContinue)) {
+    sudo /bin/bash $dotnetInstall -Version $Version -InstallDir $installDir
+}
+else {
+    & $dotnetInstall -Version $Version -InstallDir $installDir
+}


### PR DESCRIPTION
On ubuntu-24.04 (ubuntu-latest) the .net sdk installation path changed from `/usr/share/dotnet` to `/usr/lib/dotnet`.

The `dotnet-install.sh` requires sudo permissions.
> cp: cannot create directory '/usr/lib/dotnet/host/fxr/8.0.10/': Permission denied