### PR TITLE
benchmarks update dependencies

### DIFF
--- a/Benchmarks/Directory.Packages.props
+++ b/Benchmarks/Directory.Packages.props
@@ -3,11 +3,11 @@
 
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
-    <PackageVersion Include="MagicOnion" Version="6.1.6" />
-    <PackageVersion Include="MagicOnion.Server" Version="6.1.6" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.1" />
+    <PackageVersion Include="MagicOnion" Version="7.0.2" />
+    <PackageVersion Include="MagicOnion.Server" Version="7.0.2" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.4" />
     <PackageVersion Include="protobuf-net.Grpc" Version="1.2.2" />
     <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
-    <PackageVersion Include="System.ServiceModel.Primitives" Version="8.1.1" />
+    <PackageVersion Include="System.ServiceModel.Primitives" Version="8.1.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- MagicOnion 6.1.6 => 7.0.2
- MagicOnion.Server 6.1.6 => 7.0.2
- Microsoft.AspNetCore.TestHost 9.0.1 => 9.0.4
- System.ServiceModel.Primitives 8.1.1 => 8.1.2