### PR TITLE
remove redundant -Platform parameter

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -73,7 +73,7 @@ jobs:
 
     - name: Test
       shell: pwsh
-      run: ./Build/invoke-sdk-test.ps1 -Platform "linux"
+      run: ./Build/invoke-sdk-test.ps1
 
   sdk-test-win:
     name: win-sdk-test
@@ -102,7 +102,7 @@ jobs:
 
     - name: Test
       shell: pwsh
-      run: ./Build/invoke-sdk-test.ps1 -Platform "win"
+      run: ./Build/invoke-sdk-test.ps1
 
   sdk-test-macos:
     name: macos-sdk-test
@@ -131,7 +131,7 @@ jobs:
 
     - name: Test
       shell: pwsh
-      run: ./Build/invoke-sdk-test.ps1 -Platform "macos"
+      run: ./Build/invoke-sdk-test.ps1
 
   benchmarks:
     name: linux-benchmarks

--- a/Build/build-locally.ps1
+++ b/Build/build-locally.ps1
@@ -35,6 +35,10 @@ param (
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+if (-not $IsWindows) {
+    throw "$([Environment]::OSVersion.VersionString) is not supported."
+}
+
 . (Join-Path $PSScriptRoot 'scripts' 'Get-ModuleVersion.ps1')
 . (Join-Path $PSScriptRoot 'scripts' 'Resolve-ModulePath.ps1')
 . (Join-Path $PSScriptRoot 'scripts' 'Build-LinuxSdkImage.ps1')
@@ -63,7 +67,6 @@ if (-not $SkipLinuxSdk) {
         -v "$($repository):/repository" `
         $image `
         '/repository/Build/invoke-sdk-test.ps1' `
-        -Platform 'linux' `
         -Filter $LinuxSdkFilter
 
     if ($LASTEXITCODE) {
@@ -72,7 +75,7 @@ if (-not $SkipLinuxSdk) {
 }
 
 if (-not $SkipWinSdk) {
-    & (Join-Path $PSScriptRoot 'invoke-sdk-test.ps1') -Platform 'win' -Filter $WinSdkFilter
+    & (Join-Path $PSScriptRoot 'invoke-sdk-test.ps1') -Filter $WinSdkFilter
 }
 
 # benchmarks

--- a/Build/invoke-sdk-test.ps1
+++ b/Build/invoke-sdk-test.ps1
@@ -3,11 +3,6 @@
 
 [CmdletBinding()]
 param (
-    [Parameter(Mandatory)]
-    [ValidateSet('win', 'linux', 'macos')] 
-    [string]
-    $Platform,
-
     [Parameter()]
     [AllowNull()]
     [string]
@@ -24,6 +19,19 @@ Set-StrictMode -Version Latest
 
 $distinctPath = New-Object System.Collections.Generic.HashSet[string]
 $examples = @()
+
+if ($IsWindows) {
+    $platform = 'win'
+}
+elseif ($IsLinux) {
+    $platform = 'linux'
+}
+elseif ($IsMacOS) {
+    $platform = 'macos'
+}
+else {
+    throw "$([Environment]::OSVersion.VersionString) is not supported."
+}
 
 $configurations = Get-ChildItem -Path (Get-FullPath (Join-Path $PSScriptRoot '../Examples')) -Filter '*test-configuration.ps1' -File -Recurse
 foreach ($configuration in $configurations) {
@@ -43,7 +51,7 @@ foreach ($configuration in $configurations) {
         }
     }
 
-    if ($Platform -notin $example.Platform) {
+    if ($platform -notin $example.Platform) {
         continue
     }
 


### PR DESCRIPTION
Remove redundant `-Platform` parameter from scripts, and determine the current OS automatically. 