### PR TITLE
add GrpcCoreLogger to Grpc.Core server projects

### DIFF
--- a/Examples/Grpc.Core.DesignTime/Server/GrpcCoreLogger.cs
+++ b/Examples/Grpc.Core.DesignTime/Server/GrpcCoreLogger.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using IGrpcLogger = Grpc.Core.Logging.ILogger;
+
+namespace Server;
+
+internal sealed class GrpcCoreLogger : IGrpcLogger
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger _target;
+
+    public GrpcCoreLogger(ILoggerFactory loggerFactory)
+        : this(loggerFactory, loggerFactory.CreateLogger<GrpcCoreLogger>())
+    {
+    }
+
+    private GrpcCoreLogger(ILoggerFactory loggerFactory, ILogger target)
+    {
+        _loggerFactory = loggerFactory;
+        _target = target;
+    }
+
+    public IGrpcLogger ForType<T>() => new GrpcCoreLogger(_loggerFactory, _loggerFactory.CreateLogger<T>());
+
+    public void Debug(string message) => _target.LogDebug(message);
+
+    public void Debug(string format, params object[] formatArgs) => _target.LogDebug(format, formatArgs);
+
+    public void Info(string message) => _target.LogInformation(message);
+
+    public void Info(string format, params object[] formatArgs) => _target.LogInformation(format, formatArgs);
+
+    public void Warning(string message) => _target.LogWarning(message);
+
+    public void Warning(string format, params object[] formatArgs) => _target.LogWarning(format, formatArgs);
+
+    public void Warning(Exception exception, string message) => _target.LogWarning(exception, message);
+
+    public void Error(string message) => _target.LogError(message);
+
+    public void Error(string format, params object[] formatArgs) => _target.LogError(format, formatArgs);
+
+    public void Error(Exception exception, string message) => _target.LogError(exception, message);
+}

--- a/Examples/Grpc.Core.DesignTime/Server/ServerHost.cs
+++ b/Examples/Grpc.Core.DesignTime/Server/ServerHost.cs
@@ -5,6 +5,7 @@ using Grpc.Core;
 using Grpc.Core.Interceptors;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Server.Services;
 
 namespace Server;
@@ -17,6 +18,9 @@ internal sealed class ServerHost : IHostedService
 
     public ServerHost(IServiceProvider serviceProvider)
     {
+        // redirect Grpc.Core.Logging to Microsoft.Extensions.Logging
+        GrpcEnvironment.SetLogger(new GrpcCoreLogger(serviceProvider.GetRequiredService<ILoggerFactory>()));
+
         _server = new()
         {
             Ports = { new ServerPort("localhost", Port, ServerCredentials.Insecure) }

--- a/Examples/Grpc.Core.ReflectionEmit/Server/GrpcCoreLogger.cs
+++ b/Examples/Grpc.Core.ReflectionEmit/Server/GrpcCoreLogger.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using IGrpcLogger = Grpc.Core.Logging.ILogger;
+
+namespace Server;
+
+internal sealed class GrpcCoreLogger : IGrpcLogger
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger _target;
+
+    public GrpcCoreLogger(ILoggerFactory loggerFactory)
+        : this(loggerFactory, loggerFactory.CreateLogger<GrpcCoreLogger>())
+    {
+    }
+
+    private GrpcCoreLogger(ILoggerFactory loggerFactory, ILogger target)
+    {
+        _loggerFactory = loggerFactory;
+        _target = target;
+    }
+
+    public IGrpcLogger ForType<T>() => new GrpcCoreLogger(_loggerFactory, _loggerFactory.CreateLogger<T>());
+
+    public void Debug(string message) => _target.LogDebug(message);
+
+    public void Debug(string format, params object[] formatArgs) => _target.LogDebug(format, formatArgs);
+
+    public void Info(string message) => _target.LogInformation(message);
+
+    public void Info(string format, params object[] formatArgs) => _target.LogInformation(format, formatArgs);
+
+    public void Warning(string message) => _target.LogWarning(message);
+
+    public void Warning(string format, params object[] formatArgs) => _target.LogWarning(format, formatArgs);
+
+    public void Warning(Exception exception, string message) => _target.LogWarning(exception, message);
+
+    public void Error(string message) => _target.LogError(message);
+
+    public void Error(string format, params object[] formatArgs) => _target.LogError(format, formatArgs);
+
+    public void Error(Exception exception, string message) => _target.LogError(exception, message);
+}

--- a/Examples/Grpc.Core.ReflectionEmit/Server/ServerHost.cs
+++ b/Examples/Grpc.Core.ReflectionEmit/Server/ServerHost.cs
@@ -5,6 +5,7 @@ using Grpc.Core;
 using Grpc.Core.Interceptors;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Server.Services;
 
 namespace Server;
@@ -17,6 +18,9 @@ internal sealed class ServerHost : IHostedService
 
     public ServerHost(IServiceProvider serviceProvider)
     {
+        // redirect Grpc.Core.Logging to Microsoft.Extensions.Logging
+        GrpcEnvironment.SetLogger(new GrpcCoreLogger(serviceProvider.GetRequiredService<ILoggerFactory>()));
+
         _server = new()
         {
             Ports = { new ServerPort("localhost", Port, ServerCredentials.Insecure) }

--- a/Examples/NerdbankMessagePackMarshaller.Grpc.Core/Server/GrpcCoreLogger.cs
+++ b/Examples/NerdbankMessagePackMarshaller.Grpc.Core/Server/GrpcCoreLogger.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using IGrpcLogger = Grpc.Core.Logging.ILogger;
+
+namespace Server;
+
+internal sealed class GrpcCoreLogger : IGrpcLogger
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly ILogger _target;
+
+    public GrpcCoreLogger(ILoggerFactory loggerFactory)
+        : this(loggerFactory, loggerFactory.CreateLogger<GrpcCoreLogger>())
+    {
+    }
+
+    private GrpcCoreLogger(ILoggerFactory loggerFactory, ILogger target)
+    {
+        _loggerFactory = loggerFactory;
+        _target = target;
+    }
+
+    public IGrpcLogger ForType<T>() => new GrpcCoreLogger(_loggerFactory, _loggerFactory.CreateLogger<T>());
+
+    public void Debug(string message) => _target.LogDebug(message);
+
+    public void Debug(string format, params object[] formatArgs) => _target.LogDebug(format, formatArgs);
+
+    public void Info(string message) => _target.LogInformation(message);
+
+    public void Info(string format, params object[] formatArgs) => _target.LogInformation(format, formatArgs);
+
+    public void Warning(string message) => _target.LogWarning(message);
+
+    public void Warning(string format, params object[] formatArgs) => _target.LogWarning(format, formatArgs);
+
+    public void Warning(Exception exception, string message) => _target.LogWarning(exception, message);
+
+    public void Error(string message) => _target.LogError(message);
+
+    public void Error(string format, params object[] formatArgs) => _target.LogError(format, formatArgs);
+
+    public void Error(Exception exception, string message) => _target.LogError(exception, message);
+}

--- a/Examples/NerdbankMessagePackMarshaller.Grpc.Core/Server/ServerHost.cs
+++ b/Examples/NerdbankMessagePackMarshaller.Grpc.Core/Server/ServerHost.cs
@@ -5,6 +5,7 @@ using Contract;
 using Grpc.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Server.Services;
 using ServiceModel.Grpc.Configuration;
 using ServiceModel.Grpc.Interceptors;
@@ -19,6 +20,9 @@ internal sealed class ServerHost : IHostedService
 
     public ServerHost(IServiceProvider serviceProvider)
     {
+        // redirect Grpc.Core.Logging to Microsoft.Extensions.Logging
+        GrpcEnvironment.SetLogger(new GrpcCoreLogger(serviceProvider.GetRequiredService<ILoggerFactory>()));
+
         _server = new()
         {
             Ports = { new ServerPort("localhost", Port, ServerCredentials.Insecure) }


### PR DESCRIPTION
By default Grpc.Core.Server is silent. If any exception on server-side, nothing on console.
Extend corresponding examples with enabled Grpc.Core.Server logging

```c#
// redirect Grpc.Core.Logging to Microsoft.Extensions.Logging
GrpcEnvironment.SetLogger(new GrpcCoreLogger(serviceProvider.GetRequiredService<ILoggerFactory>()));
```