### PR TITLE
update benchmarks dependencies

### DIFF
--- a/Benchmarks/Directory.Packages.props
+++ b/Benchmarks/Directory.Packages.props
@@ -2,10 +2,10 @@
   <Import Project="..\Sources\Directory.Packages.props" />
 
   <ItemGroup>
-    <PackageVersion Include="BenchmarkDotNet" Version="0.15.1" />
-    <PackageVersion Include="MagicOnion" Version="7.0.4" />
-    <PackageVersion Include="MagicOnion.Server" Version="7.0.4" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.6" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.4" />
+    <PackageVersion Include="MagicOnion" Version="7.0.6" />
+    <PackageVersion Include="MagicOnion.Server" Version="7.0.6" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.9" />
     <PackageVersion Include="protobuf-net.Grpc" Version="1.2.2" />
     <PackageVersion Include="protobuf-net.Grpc.AspNetCore" Version="1.2.2" />
     <PackageVersion Include="System.ServiceModel.Primitives" Version="8.1.2" />


### PR DESCRIPTION
- BenchmarkDotNet 0.15.1 => 0.15.4
- MagicOnion 7.0.4 => 7.0.6
- MagicOnion.Server 7.0.4 => 7.0.6
- Microsoft.AspNetCore.TestHost 9.0.6 => 9.0.9