### PR TITLE
switch benchmarks to use NuGet references

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,9 +136,19 @@ jobs:
   benchmarks:
     name: linux-benchmarks
     runs-on: ubuntu-latest
+    needs: build
 
     steps:
     - uses: actions/checkout@v4
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: nuget-packages
+        path: build-out
+
+    - name: List artifacts
+      run: ls -R
+      working-directory: build-out
 
     - name: Install dependencies
       shell: pwsh

--- a/Benchmarks/Benchmarks.slnx
+++ b/Benchmarks/Benchmarks.slnx
@@ -1,20 +1,3 @@
 <Solution>
-  <Folder Name="/Sources/">
-    <Project Path="../Sources/ServiceModel.Grpc.AspNetCore/ServiceModel.Grpc.AspNetCore.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.Core/ServiceModel.Grpc.Core.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.Descriptions/ServiceModel.Grpc.Descriptions.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.CSharp/ServiceModel.Grpc.DesignTime.CodeAnalysis.CSharp.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal/ServiceModel.Grpc.DesignTime.CodeAnalysis.Internal.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.DesignTime.CodeAnalysis/ServiceModel.Grpc.DesignTime.CodeAnalysis.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.DesignTime.Generators/ServiceModel.Grpc.DesignTime.Generators.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.DesignTime/ServiceModel.Grpc.DesignTime.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.Emit/ServiceModel.Grpc.Emit.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.Filters/ServiceModel.Grpc.Filters.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.Interceptors/ServiceModel.Grpc.Interceptors.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.MemoryPackMarshaller/ServiceModel.Grpc.MemoryPackMarshaller.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.MessagePackMarshaller/ServiceModel.Grpc.MessagePackMarshaller.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc.ProtoBufMarshaller/ServiceModel.Grpc.ProtoBufMarshaller.csproj" />
-    <Project Path="../Sources/ServiceModel.Grpc/ServiceModel.Grpc.csproj" />
-  </Folder>
   <Project Path="ServiceModel.Grpc.Benchmarks/ServiceModel.Grpc.Benchmarks.csproj" />
 </Solution>

--- a/Benchmarks/Directory.Packages.props
+++ b/Benchmarks/Directory.Packages.props
@@ -2,6 +2,11 @@
   <Import Project="..\Sources\Directory.Packages.props" />
 
   <ItemGroup>
+    <PackageVersion Include="ServiceModel.Grpc.AspNetCore" Version="$(ServiceModelGrpcVersion)" />
+    <PackageVersion Include="ServiceModel.Grpc.MemoryPackMarshaller" Version="$(ServiceModelGrpcVersion)" />
+    <PackageVersion Include="ServiceModel.Grpc.MessagePackMarshaller" Version="$(ServiceModelGrpcVersion)" />
+    <PackageVersion Include="ServiceModel.Grpc.ProtoBufMarshaller" Version="$(ServiceModelGrpcVersion)" />
+
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.4" />
     <PackageVersion Include="MagicOnion" Version="7.0.6" />
     <PackageVersion Include="MagicOnion.Server" Version="7.0.6" />

--- a/Benchmarks/ServiceModel.Grpc.Benchmarks/ServiceModel.Grpc.Benchmarks.csproj
+++ b/Benchmarks/ServiceModel.Grpc.Benchmarks/ServiceModel.Grpc.Benchmarks.csproj
@@ -7,6 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ServiceModel.Grpc.AspNetCore" />
+    <PackageReference Include="ServiceModel.Grpc.MemoryPackMarshaller" />
+    <PackageReference Include="ServiceModel.Grpc.MessagePackMarshaller" />
+    <PackageReference Include="ServiceModel.Grpc.ProtoBufMarshaller" />
+
     <PackageReference Include="BenchmarkDotNet" />
     <PackageReference Include="Grpc.Net.Client" />
     <PackageReference Include="MagicOnion" />
@@ -17,14 +22,6 @@
     <PackageReference Include="System.ServiceModel.Primitives" />
     <PackageReference Include="Google.Protobuf" />
     <PackageReference Include="Grpc.Tools" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\..\Sources\ServiceModel.Grpc.AspNetCore\ServiceModel.Grpc.AspNetCore.csproj" />
-    <ProjectReference Include="..\..\Sources\ServiceModel.Grpc.MemoryPackMarshaller\ServiceModel.Grpc.MemoryPackMarshaller.csproj" />
-    <ProjectReference Include="..\..\Sources\ServiceModel.Grpc.MessagePackMarshaller\ServiceModel.Grpc.MessagePackMarshaller.csproj" />
-    <ProjectReference Include="..\..\Sources\ServiceModel.Grpc.ProtoBufMarshaller\ServiceModel.Grpc.ProtoBufMarshaller.csproj" />
-    <ProjectReference Include="..\..\Sources\ServiceModel.Grpc\ServiceModel.Grpc.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Build/invoke-benchmarks.ps1
+++ b/Build/invoke-benchmarks.ps1
@@ -12,8 +12,12 @@ param (
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version Latest
 
+. (Join-Path $PSScriptRoot 'scripts' 'Add-NugetSource.ps1')
+. (Join-Path $PSScriptRoot 'scripts' 'Clear-NugetCache.ps1')
 . (Join-Path $PSScriptRoot 'scripts' 'Get-FullPath.ps1')
+. (Join-Path $PSScriptRoot 'scripts' 'Get-NugetPath.ps1')
 . (Join-Path $PSScriptRoot 'scripts' 'Remove-DirectoryRecurse.ps1')
+. (Join-Path $PSScriptRoot 'scripts' 'Remove-NugetSource.ps1')
 
 Invoke-Build `
     -File (Join-Path $PSScriptRoot 'tasks' 'benchmarks-tasks.ps1') `

--- a/Build/tasks/benchmarks-tasks.ps1
+++ b/Build/tasks/benchmarks-tasks.ps1
@@ -14,11 +14,18 @@ param(
     $Configuration
 )
 
-task . Clean, Build, Run, CopyResults
+task . Clean, Build, Run, CopyResults, TestResults
 
 Enter-Build {
     $pathApp = Join-Path $PathSources 'ServiceModel.Grpc.Benchmarks/bin' $Configuration
     $pathBuildOutArtifacts = Join-Path $PathBuildOut 'BenchmarkDotNet.Artifacts'
+    Clear-NugetCache
+    Add-NugetSource -Path $PathBuildOut
+}
+
+Exit-Build {
+    Remove-NugetSource
+    Clear-NugetCache
 }
 
 task Clean {
@@ -46,5 +53,13 @@ task CopyResults {
     if ($Configuration -eq 'Release') {
         $source = Join-Path $pathApp 'BenchmarkDotNet.Artifacts/results'
         Move-Item -Path $source $pathBuildOutArtifacts -Force
+    }
+}
+
+task TestResults -If ($Configuration -eq 'Release') {
+    $files = Get-ChildItem -Path $pathBuildOutArtifacts -File -Filter '*.md'
+    $files
+    if (($files -isnot [array]) -or ($files.Length -le 2)) {
+        throw 'It seems that BenchmarkDotNet failed to create artifacts.'
     }
 }


### PR DESCRIPTION
before

```xml
  <ItemGroup>
    <ProjectReference Include="Sources\ServiceModel.Grpc.AspNetCore.csproj" />
    <ProjectReference Include="Sources\ServiceModel.Grpc.MemoryPackMarshaller.csproj" />
    <ProjectReference Include="Sources\ServiceModel.Grpc.MessagePackMarshaller.csproj" />
    <ProjectReference Include="Sources\ServiceModel.Grpc.ProtoBufMarshaller.csproj" />
  </ItemGroup>
```

after

```xml
  <ItemGroup>
    <PackageReference Include="ServiceModel.Grpc.AspNetCore" />
    <PackageReference Include="ServiceModel.Grpc.MemoryPackMarshaller" />
    <PackageReference Include="ServiceModel.Grpc.MessagePackMarshaller" />
    <PackageReference Include="ServiceModel.Grpc.ProtoBufMarshaller" />
  </ItemGroup>
```