### PR TITLE
update Grpc.Net

### DIFF
--- a/Examples/Directory.Packages.props
+++ b/Examples/Directory.Packages.props
@@ -17,14 +17,14 @@
     <PackageVersion Include="ServiceModel.Grpc.AspNetCore.Swashbuckle" Version="$(ServiceModelGrpcVersion)" />
     <PackageVersion Include="ServiceModel.Grpc.AspNetCore.NSwag" Version="$(ServiceModelGrpcVersion)" />
 
-    <PackageVersion Include="Grpc.Net.Client" Version="2.71.0" />
-    <PackageVersion Include="Grpc.Net.Client.Web" Version="2.71.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.71.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.71.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
+    <PackageVersion Include="Grpc.Net.Client.Web" Version="2.76.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.76.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.76.0" />
 
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
-    <PackageVersion Include="Google.Protobuf" Version="3.33.1" />
+    <PackageVersion Include="Google.Protobuf" Version="3.33.2" />
 
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.0" />

--- a/Sources/Directory.Packages.props
+++ b/Sources/Directory.Packages.props
@@ -5,12 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Google.Protobuf" Version="3.33.1" />
-    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.71.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.33.2" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.76.0" />
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />
-    <PackageVersion Include="Grpc.Core.Api" Version="2.71.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.71.0" />
-    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.71.0" />
+    <PackageVersion Include="Grpc.Core.Api" Version="2.76.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.76.0" />
+    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.76.0" />
     <PackageVersion Include="Grpc.Tools" Version="2.76.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.4" />
     <PackageVersion Include="MessagePack" Version="3.1.4" />


### PR DESCRIPTION
- Grpc.Core.Api 2.71.0 => 2.76.0
- Grpc.Net.Client 2.71.0 => 2.76.0
- Grpc.Net.ClientFactory 2.71.0 => 2.76.0
- Grpc.AspNetCore.Server 2.71.0 => 2.76.0
- Google.Protobuf 3.33.1 => 3.33.2