### PR TITLE
update Grpc.Net

### DIFF
--- a/Examples/Directory.Packages.props
+++ b/Examples/Directory.Packages.props
@@ -17,14 +17,14 @@
     <PackageVersion Include="ServiceModel.Grpc.AspNetCore.Swashbuckle" Version="$(ServiceModelGrpcVersion)" />
     <PackageVersion Include="ServiceModel.Grpc.AspNetCore.NSwag" Version="$(ServiceModelGrpcVersion)" />
 
-    <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
-    <PackageVersion Include="Grpc.Net.Client.Web" Version="2.80.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.80.0" />
-    <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.80.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />
+    <PackageVersion Include="Grpc.Net.Client.Web" Version="2.83.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.83.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Web" Version="2.83.0" />
 
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />
-    <PackageVersion Include="Grpc.Tools" Version="2.81.1" />
-    <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
+    <PackageVersion Include="Grpc.Tools" Version="2.83.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.36.0" />
 
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />

--- a/Sources/Directory.Packages.props
+++ b/Sources/Directory.Packages.props
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Google.Protobuf" Version="3.35.1" />
-    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.80.0" />
+    <PackageVersion Include="Google.Protobuf" Version="3.36.0" />
+    <PackageVersion Include="Grpc.AspNetCore.Server" Version="2.83.0" />
     <PackageVersion Include="Grpc.Core" Version="2.46.6" />
-    <PackageVersion Include="Grpc.Core.Api" Version="2.80.0" />
-    <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
-    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.80.0" />
-    <PackageVersion Include="Grpc.Tools" Version="2.81.1" />
+    <PackageVersion Include="Grpc.Core.Api" Version="2.83.0" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.83.0" />
+    <PackageVersion Include="Grpc.Net.ClientFactory" Version="2.83.0" />
+    <PackageVersion Include="Grpc.Tools" Version="2.83.0" />
     <PackageVersion Include="MemoryPack" Version="1.21.4" />
     <PackageVersion Include="MessagePack" Version="3.1.7" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.28" />


### PR DESCRIPTION
- Grpc.Core.Api 2.80.0 => 2.83.0
- Grpc.Net.Client 2.80.0 => 2.83.0
- Grpc.Net.ClientFactory 2.80.0 => 2.83.0
- Grpc.AspNetCore.Server 2.80.0 => 2.83.0
- Grpc.Tools 2.81.1 => 2.83.0
- Google.Protobuf 3.35.1 => 3.36.0